### PR TITLE
Make viewport zoom sensitivity consistent, correct "percent" typo

### DIFF
--- a/PixiEditor/Models/Tools/Tools/ZoomTool.cs
+++ b/PixiEditor/Models/Tools/Tools/ZoomTool.cs
@@ -11,7 +11,7 @@ namespace PixiEditor.Models.Tools.Tools
 {
     public class ZoomTool : ReadonlyTool
     {
-        public const float MaxZoomMultiplier = 5f;
+        public const float ZoomSensitivityMultiplier = 30f;
         public override ToolType ToolType => ToolType.Zoom;
         private double _startingX;
         private double _workAreaWidth = SystemParameters.WorkArea.Width;
@@ -22,7 +22,7 @@ namespace PixiEditor.Models.Tools.Tools
             HideHighlight = true;
             CanStartOutsideCanvas = true;
             Tooltip = "Zooms viewport (Z). Click to zoom in, hold alt and click to zoom out.";
-            _pixelsPerZoomMultiplier = _workAreaWidth / MaxZoomMultiplier; //Eg. 1200 px screen width / 5x zoom max = 240 px per 1x diff.
+            _pixelsPerZoomMultiplier = _workAreaWidth / ZoomSensitivityMultiplier;
         }
 
         public override void OnMouseDown(MouseEventArgs e)
@@ -37,10 +37,9 @@ namespace PixiEditor.Models.Tools.Tools
             {
                 double xPos = MousePositionConverter.GetCursorPosition().X;
 
-                double rawPrecentDifference = (xPos - _startingX) / _pixelsPerZoomMultiplier; //raw = 0-1 range
-                double normalizedPrecentDifference = rawPrecentDifference * 100.0; // To 0-100 range
-                double sumZoomPrecent = normalizedPrecentDifference + 100; // We are adding 100, so we can get the final zoom precent relative to original
-                Zoom(sumZoomPrecent);
+                double rawPercentDifference = (xPos - _startingX) / _pixelsPerZoomMultiplier; //negative - zoom out, positive - zoom in, linear
+                double finalPercentDifference = Math.Pow(2, rawPercentDifference) * 100.0; //less than 100 - zoom out, greater than 100 - zoom in
+                Zoom(finalPercentDifference);
             }
         }
 

--- a/PixiEditor/Views/MainDrawingPanel.xaml.cs
+++ b/PixiEditor/Views/MainDrawingPanel.xaml.cs
@@ -49,12 +49,12 @@ namespace PixiEditor.Views
 
         public double ZoomPercentage
         {
-            get { return (double)GetValue(ZoomPrecentageProperty); }
-            set { SetValue(ZoomPrecentageProperty, value); }
+            get { return (double)GetValue(ZoomPercentageProperty); }
+            set { SetValue(ZoomPercentageProperty, value); }
         }
 
-        // Using a DependencyProperty as the backing store for ZoomPrecentage.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty ZoomPrecentageProperty =
+        // Using a DependencyProperty as the backing store for ZoomPercentage.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty ZoomPercentageProperty =
             DependencyProperty.Register("ZoomPercentage", typeof(double), typeof(MainDrawingPanel), new PropertyMetadata(0.0, ZoomPercentegeChanged));
 
 


### PR DESCRIPTION
Dragging zoom tool left and right now feels more intuitive (sensitivity does not depend on current zoom level now)
Also, "percent" was spelled incorrectly