### PR TITLE
Add a tool size increase and decrease shortcuts using [ and ]

### DIFF
--- a/PixiEditor/Models/Controllers/BitmapManager.cs
+++ b/PixiEditor/Models/Controllers/BitmapManager.cs
@@ -12,6 +12,7 @@ using PixiEditor.Models.ImageManipulation;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
 using PixiEditor.Models.Tools;
+using PixiEditor.Models.Tools.ToolSettings;
 
 namespace PixiEditor.Models.Controllers
 {
@@ -50,7 +51,10 @@ namespace PixiEditor.Models.Controllers
             : 1;
             set
             {
-                SelectedTool.Toolbar.GetSetting("ToolSize").Value = value;
+                if (SelectedTool.Toolbar.GetSetting("ToolSize") is Setting toolSize)
+                {
+                    toolSize.Value = value;
+                }
             }
         }
 

--- a/PixiEditor/Models/Controllers/BitmapManager.cs
+++ b/PixiEditor/Models/Controllers/BitmapManager.cs
@@ -54,6 +54,7 @@ namespace PixiEditor.Models.Controllers
                 if (SelectedTool.Toolbar.GetSetting("ToolSize") is Setting toolSize)
                 {
                     toolSize.Value = value;
+                    HighlightPixels(MousePositionConverter.CurrentCoordinates);
                 }
             }
         }

--- a/PixiEditor/Models/Controllers/BitmapManager.cs
+++ b/PixiEditor/Models/Controllers/BitmapManager.cs
@@ -43,9 +43,16 @@ namespace PixiEditor.Models.Controllers
 
         public Color PrimaryColor { get; set; }
 
-        public int ToolSize => SelectedTool.Toolbar.GetSetting("ToolSize") != null
-            ? (int) SelectedTool.Toolbar.GetSetting("ToolSize").Value
+        public int ToolSize
+        {
+            get => SelectedTool.Toolbar.GetSetting("ToolSize") != null
+            ? (int)SelectedTool.Toolbar.GetSetting("ToolSize").Value
             : 1;
+            set
+            {
+                SelectedTool.Toolbar.GetSetting("ToolSize").Value = value;
+            }
+        }
 
         public BitmapOperationsUtility BitmapOperations { get; set; }
         public ReadonlyToolUtility ReadonlyToolUtility { get; set; }

--- a/PixiEditor/ViewModels/ViewModelMain.cs
+++ b/PixiEditor/ViewModels/ViewModelMain.cs
@@ -80,6 +80,7 @@ namespace PixiEditor.ViewModels
         public RelayCommand CenterContentCommand { get; set; }
         public RelayCommand OpenHyperlinkCommand { get; set; }
         public RelayCommand ZoomCommand { get; set; }
+        public RelayCommand ChangeToolSizeCommand { get; set; }
 
 
         private double _mouseXonCanvas;
@@ -178,7 +179,6 @@ namespace PixiEditor.ViewModels
             }
         }
 
-
         public BitmapManager BitmapManager { get; set; }
         public PixelChangesController ChangesController { get; set; }
 
@@ -239,6 +239,7 @@ namespace PixiEditor.ViewModels
             CenterContentCommand = new RelayCommand(CenterContent, DocumentIsNotNull);
             OpenHyperlinkCommand = new RelayCommand(OpenHyperlink);
             ZoomCommand = new RelayCommand(ZoomViewport);
+            ChangeToolSizeCommand = new RelayCommand(ChangeToolSize);
             ToolSet = new ObservableCollection<Tool>
             {
                 new MoveTool(), new PenTool(), new SelectTool(), new FloodFill(), new LineTool(),
@@ -263,6 +264,8 @@ namespace PixiEditor.ViewModels
                     new Shortcut(Key.Z, SelectToolCommand, ToolType.Zoom),
                     new Shortcut(Key.OemPlus, ZoomCommand, 115),
                     new Shortcut(Key.OemMinus, ZoomCommand, 85),
+                    new Shortcut(Key.OemOpenBrackets, ChangeToolSizeCommand, -1),
+                    new Shortcut(Key.OemCloseBrackets, ChangeToolSizeCommand, 1),
                     //Editor
                     new Shortcut(Key.X, SwapColorsCommand),
                     new Shortcut(Key.Y, RedoCommand, modifier: ModifierKeys.Control),
@@ -297,6 +300,16 @@ namespace PixiEditor.ViewModels
             double zoom = (int)parameter;
             ZoomPercentage = zoom;
             ZoomPercentage = 100;
+        }
+
+        private void ChangeToolSize(object parameter)
+        {
+            int increment = (int)parameter;
+            int newSize = BitmapManager.ToolSize + increment;
+            if (newSize > 0)
+            {
+                BitmapManager.ToolSize = newSize;
+            }
         }
 
         private void OpenHyperlink(object parameter)


### PR DESCRIPTION
- Added new shortcut bindings for '[' and ']' in View Model with -1 and +1 parameter for decrease and increase respectively.
- Created new command 'ChangeToolsizeCommand' which executes a new method called 'ChangeToolsize'.
- Added setter for 'Toolsize' property in BitmapManager.
- 'ChangeToolsize(object parameter)' increments/decrements the current value of 'Toolsize' by the value of 'parameter' if the resultant value is > 0.

Tests:
![image](https://user-images.githubusercontent.com/57035210/92365704-8d0a9e00-f137-11ea-94ce-9d9d73b4b7ac.png)
