### PR TITLE
Clear Selection when single point is selected. Add MaximiseWindow Shortcut. Add Exit to File Menu

### DIFF
--- a/PixiEditor/Models/Tools/Tools/SelectTool.cs
+++ b/PixiEditor/Models/Tools/Tools/SelectTool.cs
@@ -37,6 +37,12 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override void OnMouseUp(MouseEventArgs e)
         {
+            if (ViewModelMain.Current.ActiveSelection.SelectedPoints.Count() <= 1)
+            {
+                // If we have not selected multiple points, clear the selection
+                ViewModelMain.Current.ActiveSelection.Clear();
+            }
+
             UndoManager.AddUndoChange(new Change("ActiveSelection", _oldSelection,
                 ViewModelMain.Current.ActiveSelection, "Select pixels"));
         }

--- a/PixiEditor/ViewModels/ViewModelMain.cs
+++ b/PixiEditor/ViewModels/ViewModelMain.cs
@@ -279,7 +279,6 @@ namespace PixiEditor.ViewModels
                     new Shortcut(Key.Delete, DeletePixelsCommand),
                     new Shortcut(Key.I, OpenResizePopupCommand, modifier: ModifierKeys.Control | ModifierKeys.Shift),
                     new Shortcut(Key.C, OpenResizePopupCommand, "canvas", ModifierKeys.Control | ModifierKeys.Shift),
-                    new Shortcut(Key.Q, SystemCommands.CloseWindowCommand, modifier: ModifierKeys.Control),
                     new Shortcut(Key.F11, SystemCommands.MaximizeWindowCommand),
                     //File
                     new Shortcut(Key.O, OpenFileCommand, modifier: ModifierKeys.Control),

--- a/PixiEditor/ViewModels/ViewModelMain.cs
+++ b/PixiEditor/ViewModels/ViewModelMain.cs
@@ -279,6 +279,8 @@ namespace PixiEditor.ViewModels
                     new Shortcut(Key.Delete, DeletePixelsCommand),
                     new Shortcut(Key.I, OpenResizePopupCommand, modifier: ModifierKeys.Control | ModifierKeys.Shift),
                     new Shortcut(Key.C, OpenResizePopupCommand, "canvas", ModifierKeys.Control | ModifierKeys.Shift),
+                    new Shortcut(Key.Q, SystemCommands.CloseWindowCommand, modifier: ModifierKeys.Control),
+                    new Shortcut(Key.F11, SystemCommands.MaximizeWindowCommand),
                     //File
                     new Shortcut(Key.O, OpenFileCommand, modifier: ModifierKeys.Control),
                     new Shortcut(Key.S, ExportFileCommand,

--- a/PixiEditor/Views/MainWindow.xaml
+++ b/PixiEditor/Views/MainWindow.xaml
@@ -82,6 +82,7 @@
                     <MenuItem Header="_Save As..." InputGestureText="Ctrl+Shift+S"
                               Command="{Binding SaveDocumentCommand}" CommandParameter="AsNew" />
                     <MenuItem Header="_Export" InputGestureText="Ctrl+Shift+Alt+S" Command="{Binding ExportFileCommand}" />
+                    <MenuItem Header="_Exit" InputGestureText="Ctrl+Q" Command="{x:Static SystemCommands.CloseWindowCommand}" />
                 </MenuItem>
                 <MenuItem Header="_Edit">
                     <MenuItem Header="_Undo" InputGestureText="Ctrl+Z" Command="{Binding UndoCommand}" />

--- a/PixiEditor/Views/MainWindow.xaml
+++ b/PixiEditor/Views/MainWindow.xaml
@@ -82,7 +82,7 @@
                     <MenuItem Header="_Save As..." InputGestureText="Ctrl+Shift+S"
                               Command="{Binding SaveDocumentCommand}" CommandParameter="AsNew" />
                     <MenuItem Header="_Export" InputGestureText="Ctrl+Shift+Alt+S" Command="{Binding ExportFileCommand}" />
-                    <MenuItem Header="_Exit" InputGestureText="Ctrl+Q" Command="{x:Static SystemCommands.CloseWindowCommand}" />
+                    <MenuItem Header="_Exit" Command="{x:Static SystemCommands.CloseWindowCommand}" />
                 </MenuItem>
                 <MenuItem Header="_Edit">
                     <MenuItem Header="_Undo" InputGestureText="Ctrl+Z" Command="{Binding UndoCommand}" />

--- a/PixiEditor/Views/MainWindow.xaml
+++ b/PixiEditor/Views/MainWindow.xaml
@@ -82,6 +82,7 @@
                     <MenuItem Header="_Save As..." InputGestureText="Ctrl+Shift+S"
                               Command="{Binding SaveDocumentCommand}" CommandParameter="AsNew" />
                     <MenuItem Header="_Export" InputGestureText="Ctrl+Shift+Alt+S" Command="{Binding ExportFileCommand}" />
+                    <Separator />
                     <MenuItem Header="_Exit" Command="{x:Static SystemCommands.CloseWindowCommand}" />
                 </MenuItem>
                 <MenuItem Header="_Edit">


### PR DESCRIPTION
 ## Pull Requests

### Modifications
* Updated SelectTool to clear the selection when a single point is clicked. The tool feels much more natural to clear by not selecting anything. It would be nice in the future to also clear the selection when we don't click on the canvas.
* Added Exit (CloseWindow) command to the File Menu, I think most applications have the ability to exit this way.
* Added MaximiseWindow (F11) shortcut.


![image](https://user-images.githubusercontent.com/19593942/93005547-e0228d80-f549-11ea-8cdc-9a024bb5d662.png)

### Testing

#### Select Tool
* Create a new file
* Make a selection of a group of points
* Select a single point
* **VERIFY** that the selection is cleared.

#### Shortcuts
* Create a new file, and add some pixels
* Select File>Exit
* **VERIFY** that the CloseWindow confirmation is displayed
* Press cancel, then reduce the size of the Window
* Press F11
* **VERIFY** that the Window is maximized.

#### Test Cases

* All test cases passing, noticed intermittent failures with the ClipboardControl tests.

