### PR TITLE
Resolved issue #49

### DIFF
--- a/PixiEditor/Models/IO/Exporter.cs
+++ b/PixiEditor/Models/IO/Exporter.cs
@@ -11,6 +11,7 @@ namespace PixiEditor.Models.IO
     public class Exporter
     {
         public static Size FileDimensions;
+
         public static string SaveDocumentPath { get; set; }
 
         /// <summary>
@@ -18,14 +19,20 @@ namespace PixiEditor.Models.IO
         /// </summary>
         /// <param name="document">Document to save</param>
         /// <param name="updateWorkspacePath">Should editor remember dialog path for further saves</param>
-        public static void SaveAsEditableFileWithDialog(Document document, bool updateWorkspacePath = false)
+        public static bool SaveAsEditableFileWithDialog(Document document, bool updateWorkspacePath = false)
         {
             SaveFileDialog dialog = new SaveFileDialog
             {
                 Filter = "PixiEditor Files | *.pixi",
                 DefaultExt = "pixi"
             };
-            if ((bool) dialog.ShowDialog()) SaveAsEditableFile(document, dialog.FileName, updateWorkspacePath);
+            if ((bool)dialog.ShowDialog())
+            {
+                SaveAsEditableFile(document, dialog.FileName, updateWorkspacePath);
+                return true;
+            }
+
+            return false;
         }
 
         public static void SaveAsEditableFile(Document document, string path, bool updateWorkspacePath = false)

--- a/PixiEditor/ViewModels/ViewModelMain.cs
+++ b/PixiEditor/ViewModels/ViewModelMain.cs
@@ -408,10 +408,15 @@ namespace PixiEditor.ViewModels
         {
             bool paramIsAsNew = parameter != null && parameter.ToString()?.ToLower() == "asnew";
             if (paramIsAsNew || Exporter.SaveDocumentPath == null)
-                Exporter.SaveAsEditableFileWithDialog(BitmapManager.ActiveDocument, !paramIsAsNew);
+            {
+                var saved = Exporter.SaveAsEditableFileWithDialog(BitmapManager.ActiveDocument, !paramIsAsNew);
+                _unsavedDocumentModified = _unsavedDocumentModified && !saved;
+            }
             else
+            {
                 Exporter.SaveAsEditableFile(BitmapManager.ActiveDocument, Exporter.SaveDocumentPath);
-            _unsavedDocumentModified = false;
+                _unsavedDocumentModified = false;
+            }
         }
 
         private void RemoveSwatch(object parameter)


### PR DESCRIPTION
Added a return value to `Exporter.SaveAsEditableFileWithDialog` indicating whether the dialog performed the save (true) or not (false).

Unfortunately it's not possible to add a meaningful test here because there is no abstraction around the file save dialog, and adding that abstraction and making it configurable in the test assembly seems to go beyond the scope of the bug.