### PR TITLE
Change object based settings to typed generics #44

### DIFF
--- a/PixiEditor/Models/Controllers/BitmapManager.cs
+++ b/PixiEditor/Models/Controllers/BitmapManager.cs
@@ -12,8 +12,6 @@ using PixiEditor.Models.ImageManipulation;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
 using PixiEditor.Models.Tools;
-using PixiEditor.Models.Tools.ToolSettings;
-using PixiEditor.Models.Tools.ToolSettings.Settings;
 
 namespace PixiEditor.Models.Controllers
 {
@@ -47,12 +45,12 @@ namespace PixiEditor.Models.Controllers
 
         public int ToolSize
         {
-            get => SelectedTool.Toolbar.GetSetting("ToolSize") != null
-            ? (int)SelectedTool.Toolbar.GetSetting("ToolSize").Value
+            get => SelectedTool.Toolbar.GetSetting<int>("ToolSize") != null
+            ? SelectedTool.Toolbar.GetSetting<int>("ToolSize").Value
             : 1;
             set
             {
-                if (SelectedTool.Toolbar.GetSetting("ToolSize") is Setting toolSize)
+                if (SelectedTool.Toolbar.GetSetting<int>("ToolSize") is var toolSize)
                 {
                     toolSize.Value = value;
                     HighlightPixels(MousePositionConverter.CurrentCoordinates);

--- a/PixiEditor/Models/Controllers/BitmapManager.cs
+++ b/PixiEditor/Models/Controllers/BitmapManager.cs
@@ -12,6 +12,7 @@ using PixiEditor.Models.ImageManipulation;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
 using PixiEditor.Models.Tools;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 
 namespace PixiEditor.Models.Controllers
 {
@@ -45,12 +46,12 @@ namespace PixiEditor.Models.Controllers
 
         public int ToolSize
         {
-            get => SelectedTool.Toolbar.GetSetting<int>("ToolSize") != null
-            ? SelectedTool.Toolbar.GetSetting<int>("ToolSize").Value
+            get => SelectedTool.Toolbar.GetSetting<SizeSetting>("ToolSize") != null
+            ? SelectedTool.Toolbar.GetSetting<SizeSetting>("ToolSize").Value
             : 1;
             set
             {
-                if (SelectedTool.Toolbar.GetSetting<int>("ToolSize") is var toolSize)
+                if (SelectedTool.Toolbar.GetSetting<SizeSetting>("ToolSize") is var toolSize)
                 {
                     toolSize.Value = value;
                     HighlightPixels(MousePositionConverter.CurrentCoordinates);

--- a/PixiEditor/Models/Controllers/BitmapManager.cs
+++ b/PixiEditor/Models/Controllers/BitmapManager.cs
@@ -13,6 +13,7 @@ using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
 using PixiEditor.Models.Tools;
 using PixiEditor.Models.Tools.ToolSettings;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 
 namespace PixiEditor.Models.Controllers
 {

--- a/PixiEditor/Models/Tools/ToolSettings/Settings/BoolSetting.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Settings/BoolSetting.cs
@@ -5,7 +5,7 @@ using System.Windows.Data;
 
 namespace PixiEditor.Models.Tools.ToolSettings.Settings
 {
-    public class BoolSetting : Setting
+    public class BoolSetting : Setting<bool>
     {
         public BoolSetting(string name, string label = "") : base(name)
         {
@@ -25,7 +25,7 @@ namespace PixiEditor.Models.Tools.ToolSettings.Settings
         {
             CheckBox checkBox = new CheckBox
             {
-                IsChecked = (bool) Value,
+                IsChecked = Value,
                 VerticalAlignment = VerticalAlignment.Center
             };
 

--- a/PixiEditor/Models/Tools/ToolSettings/Settings/ColorSetting.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Settings/ColorSetting.cs
@@ -4,7 +4,7 @@ using ColorPicker;
 
 namespace PixiEditor.Models.Tools.ToolSettings.Settings
 {
-    public class ColorSetting : Setting
+    public class ColorSetting : Setting<Color>
     {
         public ColorSetting(string name, string label = "") : base(name)
         {

--- a/PixiEditor/Models/Tools/ToolSettings/Settings/DropdownSetting.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Settings/DropdownSetting.cs
@@ -5,7 +5,7 @@ using System.Windows.Data;
 
 namespace PixiEditor.Models.Tools.ToolSettings.Settings
 {
-    public class DropdownSetting : Setting
+    public class DropdownSetting : Setting<object>
     {
         public string[] Values { get; set; }
 

--- a/PixiEditor/Models/Tools/ToolSettings/Settings/FloatSetting.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Settings/FloatSetting.cs
@@ -3,7 +3,7 @@ using PixiEditor.Views;
 
 namespace PixiEditor.Models.Tools.ToolSettings.Settings
 {
-    public class FloatSetting : Setting
+    public class FloatSetting : Setting<float>
     {
         public float Min { get; set; }
         public float Max { get; set; }

--- a/PixiEditor/Models/Tools/ToolSettings/Settings/Setting.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Settings/Setting.cs
@@ -3,13 +3,14 @@ using PixiEditor.Helpers;
 
 namespace PixiEditor.Models.Tools.ToolSettings.Settings
 {
-    public abstract class Setting<T> : NotifyableObject
+    public abstract class Setting<T> : Setting
     {
-        public string Name { get; }
+        private T value;
 
-        public string Label { get; set; }
-
-        public bool HasLabel => !string.IsNullOrEmpty(Label);
+        protected Setting(string name)
+            : base(name)
+        {
+        }
 
         public T Value
         {
@@ -20,22 +21,21 @@ namespace PixiEditor.Models.Tools.ToolSettings.Settings
                 RaisePropertyChanged("Value");
             }
         }
+    }
+
+    public abstract class Setting : NotifyableObject
+    {
+        public string Name { get; }
+
+        public string Label { get; set; }
+
+        public bool HasLabel => !string.IsNullOrEmpty(Label);
 
         public Control SettingControl { get; set; }
-
-        private T value;
 
         protected Setting(string name)
         {
             Name = name;
-        }
-    }
-
-    public abstract class Setting : Setting<object>
-    {
-        protected Setting(string name)
-            : base(name)
-        {
         }
     }
 }

--- a/PixiEditor/Models/Tools/ToolSettings/Settings/Setting.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Settings/Setting.cs
@@ -1,15 +1,17 @@
 ﻿using System.Windows.Controls;
 using PixiEditor.Helpers;
 
-namespace PixiEditor.Models.Tools.ToolSettings
+namespace PixiEditor.Models.Tools.ToolSettings.Settings
 {
-    public abstract class Setting : NotifyableObject
+    public abstract class Setting<T> : NotifyableObject
     {
-        public string Name { get; protected set; }
+        public string Name { get; }
+
         public string Label { get; set; }
+
         public bool HasLabel => !string.IsNullOrEmpty(Label);
 
-        public object Value
+        public T Value
         {
             get => value;
             set
@@ -20,11 +22,20 @@ namespace PixiEditor.Models.Tools.ToolSettings
         }
 
         public Control SettingControl { get; set; }
-        private object value;
 
-        public Setting(string name)
+        private T value;
+
+        protected Setting(string name)
         {
             Name = name;
+        }
+    }
+
+    public abstract class Setting : Setting<object>
+    {
+        protected Setting(string name)
+            : base(name)
+        {
         }
     }
 }

--- a/PixiEditor/Models/Tools/ToolSettings/Settings/SizeSetting.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Settings/SizeSetting.cs
@@ -7,7 +7,7 @@ using PixiEditor.Helpers.Behaviours;
 
 namespace PixiEditor.Models.Tools.ToolSettings.Settings
 {
-    public class SizeSetting : Setting
+    public class SizeSetting : Setting<int>
     {
         public SizeSetting(string name, string label = null) : base(name)
         {
@@ -28,7 +28,7 @@ namespace PixiEditor.Models.Tools.ToolSettings.Settings
 
             if (Application.Current != null)
             {
-                tb.Style = (Style)Application.Current.TryFindResource("DarkTextBoxStyle"); ;
+                tb.Style = (Style)Application.Current.TryFindResource("DarkTextBoxStyle");
             }
 
             Binding binding = new Binding("Value")

--- a/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
@@ -22,15 +22,33 @@ namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
         }
 
         /// <summary>
+        ///     Gets setting with given type T in toolbar by name.
+        /// </summary>
+        /// <param name="name">Setting name, non case sensitive</param>
+        /// <returns></returns>
+        public Setting<T> GetSetting<T>(string name)
+        {
+            Setting setting =  Settings.FirstOrDefault(currentSetting => string.Equals(currentSetting.Name, name, StringComparison.CurrentCultureIgnoreCase));
+
+            if (setting == null)
+                return null;
+
+            if (setting is Setting<T> convertedSetting)
+                return convertedSetting;
+
+            throw new Exception("Setting has value with unexpected type");
+        }
+
+        /// <summary>
         ///     Saves current toolbar state, so other toolbars with common settings can load them.
         /// </summary>
         public void SaveToolbarSettings()
         {
-            for (int i = 0; i < Settings.Count; i++)
-                if (SharedSettings.Any(x => x.Name == Settings[i].Name))
-                    SharedSettings.First(x => x.Name == Settings[i].Name).Value = Settings[i].Value;
-                else
-                    SharedSettings.Add(Settings[i]);
+            SharedSettings.Clear();
+            foreach (Setting setting in Settings)
+            {
+                SharedSettings.Add(setting);
+            }
         }
 
         /// <summary>
@@ -38,9 +56,11 @@ namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
         /// </summary>
         public void LoadSharedSettings()
         {
-            for (int i = 0; i < SharedSettings.Count; i++)
-                if (Settings.Any(x => x.Name == SharedSettings[i].Name))
-                    Settings.First(x => x.Name == SharedSettings[i].Name).Value = SharedSettings[i].Value;
+            Settings.Clear();
+            foreach (Setting setting in SharedSettings)
+            {
+                Settings.Add(setting);
+            }
         }
     }
 }

--- a/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 
 namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
 {

--- a/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
@@ -30,13 +30,10 @@ namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
         {
             Setting setting =  Settings.FirstOrDefault(currentSetting => string.Equals(currentSetting.Name, name, StringComparison.CurrentCultureIgnoreCase));
 
-            if (setting == null)
+            if (setting == null || !(setting is Setting<T> convertedSetting))
                 return null;
 
-            if (setting is Setting<T> convertedSetting)
-                return convertedSetting;
-
-            throw new Exception("Setting has value with unexpected type");
+            return convertedSetting;
         }
 
         /// <summary>

--- a/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
@@ -22,15 +22,16 @@ namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
         }
 
         /// <summary>
-        ///     Gets setting with given type T in toolbar by name.
+        ///     Gets setting of given type T in toolbar by name.
         /// </summary>
         /// <param name="name">Setting name, non case sensitive</param>
         /// <returns></returns>
-        public Setting<T> GetSetting<T>(string name)
+        public T GetSetting<T>(string name)
+            where T : Setting
         {
             Setting setting =  Settings.FirstOrDefault(currentSetting => string.Equals(currentSetting.Name, name, StringComparison.CurrentCultureIgnoreCase));
 
-            if (setting == null || !(setting is Setting<T> convertedSetting))
+            if (setting == null || !(setting is T convertedSetting))
                 return null;
 
             return convertedSetting;

--- a/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
@@ -44,11 +44,8 @@ namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
         /// </summary>
         public void SaveToolbarSettings()
         {
-            SharedSettings.Clear();
             foreach (Setting setting in Settings)
-            {
-                SharedSettings.Add(setting);
-            }
+                AddSettingToCollection(SharedSettings, setting);
         }
 
         /// <summary>
@@ -56,11 +53,17 @@ namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
         /// </summary>
         public void LoadSharedSettings()
         {
-            Settings.Clear();
-            foreach (Setting setting in SharedSettings)
-            {
-                Settings.Add(setting);
-            }
+            foreach (Setting sharedSetting in SharedSettings)
+                AddSettingToCollection(Settings, sharedSetting);
+        }
+
+        private static void AddSettingToCollection(ICollection<Setting> collection, Setting setting)
+        {
+            Setting storedSetting = collection.FirstOrDefault(currentSetting => currentSetting.Name == setting.Name);
+            if (storedSetting != null)
+                collection.Remove(storedSetting);
+
+            collection.Add(setting);
         }
     }
 }

--- a/PixiEditor/Models/Tools/Tools/BrightnessTool.cs
+++ b/PixiEditor/Models/Tools/Tools/BrightnessTool.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using PixiEditor.Models.Colors;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Enums;
@@ -35,9 +34,9 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override LayerChange[] Use(Layer layer, Coordinates[] coordinates, Color color)
         {
-            int toolSize = (int) Toolbar.GetSetting("ToolSize").Value;
-            float correctionFactor = (float) Toolbar.GetSetting("CorrectionFactor").Value;
-            Enum.TryParse<BrightnessMode>((Toolbar.GetSetting("Mode").Value as ComboBoxItem)?.Content as string, out var mode);
+            int toolSize = Toolbar.GetSetting<int>("ToolSize").Value;
+            float correctionFactor = Toolbar.GetSetting<float>("CorrectionFactor").Value;
+            Enum.TryParse<BrightnessMode>((Toolbar.GetSetting<object>("Mode").Value as ComboBoxItem)?.Content as string, out var mode);
             Mode = mode;
 
             LayerChange[] layersChanges = new LayerChange[1];

--- a/PixiEditor/Models/Tools/Tools/BrightnessTool.cs
+++ b/PixiEditor/Models/Tools/Tools/BrightnessTool.cs
@@ -8,6 +8,7 @@ using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Enums;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 using PixiEditor.Models.Tools.ToolSettings.Toolbars;
 
 namespace PixiEditor.Models.Tools.Tools
@@ -34,9 +35,9 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override LayerChange[] Use(Layer layer, Coordinates[] coordinates, Color color)
         {
-            int toolSize = Toolbar.GetSetting<int>("ToolSize").Value;
-            float correctionFactor = Toolbar.GetSetting<float>("CorrectionFactor").Value;
-            Enum.TryParse<BrightnessMode>(Toolbar.GetSetting<ComboBoxItem>("Mode")?.Value?.Content as string, out var mode);
+            int toolSize = Toolbar.GetSetting<SizeSetting>("ToolSize").Value;
+            float correctionFactor = Toolbar.GetSetting<FloatSetting>("CorrectionFactor").Value;
+            Enum.TryParse((Toolbar.GetSetting<DropdownSetting>("Mode")?.Value as ComboBoxItem)?.Content as string, out BrightnessMode mode);
             Mode = mode;
 
             LayerChange[] layersChanges = new LayerChange[1];

--- a/PixiEditor/Models/Tools/Tools/BrightnessTool.cs
+++ b/PixiEditor/Models/Tools/Tools/BrightnessTool.cs
@@ -36,7 +36,7 @@ namespace PixiEditor.Models.Tools.Tools
         {
             int toolSize = Toolbar.GetSetting<int>("ToolSize").Value;
             float correctionFactor = Toolbar.GetSetting<float>("CorrectionFactor").Value;
-            Enum.TryParse<BrightnessMode>((Toolbar.GetSetting<object>("Mode").Value as ComboBoxItem)?.Content as string, out var mode);
+            Enum.TryParse<BrightnessMode>(Toolbar.GetSetting<ComboBoxItem>("Mode")?.Value?.Content as string, out var mode);
             Mode = mode;
 
             LayerChange[] layersChanges = new LayerChange[1];

--- a/PixiEditor/Models/Tools/Tools/CircleTool.cs
+++ b/PixiEditor/Models/Tools/Tools/CircleTool.cs
@@ -22,13 +22,13 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override LayerChange[] Use(Layer layer, Coordinates[] coordinates, Color color)
         {
-            int thickness = (int) Toolbar.GetSetting("ToolSize").Value;
+            int thickness = Toolbar.GetSetting<int>("ToolSize").Value;
             DoubleCords fixedCoordinates = CalculateCoordinatesForShapeRotation(coordinates[^1], coordinates[0]);
             IEnumerable<Coordinates> outline = CreateEllipse(fixedCoordinates.Coords1, fixedCoordinates.Coords2, thickness);
             BitmapPixelChanges pixels = BitmapPixelChanges.FromSingleColoredArray(outline, color);
-            if ((bool) Toolbar.GetSetting("Fill").Value)
+            if (Toolbar.GetSetting<bool>("Fill").Value)
             {
-                Color fillColor = (Color) Toolbar.GetSetting("FillColor").Value;
+                Color fillColor = Toolbar.GetSetting<Color>("FillColor").Value;
                 pixels.ChangedPixels.AddRangeNewOnly(
                     BitmapPixelChanges.FromSingleColoredArray(CalculateFillForEllipse(outline), fillColor)
                         .ChangedPixels);

--- a/PixiEditor/Models/Tools/Tools/CircleTool.cs
+++ b/PixiEditor/Models/Tools/Tools/CircleTool.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Numerics;
 using System.Windows.Media;
 using PixiEditor.Helpers.Extensions;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 
 namespace PixiEditor.Models.Tools.Tools
 {
@@ -22,13 +21,13 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override LayerChange[] Use(Layer layer, Coordinates[] coordinates, Color color)
         {
-            int thickness = Toolbar.GetSetting<int>("ToolSize").Value;
+            int thickness = Toolbar.GetSetting<SizeSetting>("ToolSize").Value;
             DoubleCords fixedCoordinates = CalculateCoordinatesForShapeRotation(coordinates[^1], coordinates[0]);
             IEnumerable<Coordinates> outline = CreateEllipse(fixedCoordinates.Coords1, fixedCoordinates.Coords2, thickness);
             BitmapPixelChanges pixels = BitmapPixelChanges.FromSingleColoredArray(outline, color);
-            if (Toolbar.GetSetting<bool>("Fill").Value)
+            if (Toolbar.GetSetting<BoolSetting>("Fill").Value)
             {
-                Color fillColor = Toolbar.GetSetting<Color>("FillColor").Value;
+                Color fillColor = Toolbar.GetSetting<ColorSetting>("FillColor").Value;
                 pixels.ChangedPixels.AddRangeNewOnly(
                     BitmapPixelChanges.FromSingleColoredArray(CalculateFillForEllipse(outline), fillColor)
                         .ChangedPixels);

--- a/PixiEditor/Models/Tools/Tools/EraserTool.cs
+++ b/PixiEditor/Models/Tools/Tools/EraserTool.cs
@@ -2,6 +2,7 @@
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 using PixiEditor.Models.Tools.ToolSettings.Toolbars;
 
 namespace PixiEditor.Models.Tools.Tools
@@ -18,7 +19,7 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override LayerChange[] Use(Layer layer, Coordinates[] coordinates, Color color)
         {
-            return Erase(layer, coordinates, Toolbar.GetSetting<int>("ToolSize").Value);
+            return Erase(layer, coordinates, Toolbar.GetSetting<SizeSetting>("ToolSize").Value);
         }
 
         public LayerChange[] Erase(Layer layer, Coordinates[] coordinates, int toolSize)

--- a/PixiEditor/Models/Tools/Tools/EraserTool.cs
+++ b/PixiEditor/Models/Tools/Tools/EraserTool.cs
@@ -2,7 +2,6 @@
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
-using PixiEditor.Models.Tools.ToolSettings;
 using PixiEditor.Models.Tools.ToolSettings.Toolbars;
 
 namespace PixiEditor.Models.Tools.Tools
@@ -19,7 +18,7 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override LayerChange[] Use(Layer layer, Coordinates[] coordinates, Color color)
         {
-            return Erase(layer, coordinates, (int) Toolbar.GetSetting("ToolSize").Value);
+            return Erase(layer, coordinates, Toolbar.GetSetting<int>("ToolSize").Value);
         }
 
         public LayerChange[] Erase(Layer layer, Coordinates[] coordinates, int toolSize)

--- a/PixiEditor/Models/Tools/Tools/LineTool.cs
+++ b/PixiEditor/Models/Tools/Tools/LineTool.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Media;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Enums;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
-using PixiEditor.Models.Tools.ToolSettings;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 using PixiEditor.Models.Tools.ToolSettings.Toolbars;
 
 namespace PixiEditor.Models.Tools.Tools
@@ -26,7 +25,7 @@ namespace PixiEditor.Models.Tools.Tools
             var pixels =
                 BitmapPixelChanges.FromSingleColoredArray(
                     CreateLine(coordinates, 
-                        Toolbar.GetSetting<int>("ToolSize").Value, CapType.Square, CapType.Square), color);
+                        Toolbar.GetSetting<SizeSetting>("ToolSize").Value, CapType.Square, CapType.Square), color);
             return Only(pixels, layer);
         }
 

--- a/PixiEditor/Models/Tools/Tools/LineTool.cs
+++ b/PixiEditor/Models/Tools/Tools/LineTool.cs
@@ -26,7 +26,7 @@ namespace PixiEditor.Models.Tools.Tools
             var pixels =
                 BitmapPixelChanges.FromSingleColoredArray(
                     CreateLine(coordinates, 
-                        (int) Toolbar.GetSetting("ToolSize").Value, CapType.Square, CapType.Square), color);
+                        Toolbar.GetSetting<int>("ToolSize").Value, CapType.Square, CapType.Square), color);
             return Only(pixels, layer);
         }
 

--- a/PixiEditor/Models/Tools/Tools/PenTool.cs
+++ b/PixiEditor/Models/Tools/Tools/PenTool.cs
@@ -1,10 +1,9 @@
 ﻿using System.Windows.Input;
 using System.Windows.Media;
 using PixiEditor.Models.DataHolders;
-using PixiEditor.Models.Enums;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
-using PixiEditor.Models.Tools.ToolSettings;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 using PixiEditor.Models.Tools.ToolSettings.Toolbars;
 
 namespace PixiEditor.Models.Tools.Tools
@@ -12,20 +11,20 @@ namespace PixiEditor.Models.Tools.Tools
     public class PenTool : BitmapOperationTool
     {
         public override ToolType ToolType => ToolType.Pen;
-        private readonly int _toolSizeIndex;
+        private readonly Setting<int> _toolSizeSetting;
 
         public PenTool()
         {
             Cursor = Cursors.Pen;
             Tooltip = "Standard brush (B)";
             Toolbar = new BasicToolbar();
-            _toolSizeIndex = Toolbar.Settings.IndexOf(Toolbar.GetSetting("ToolSize"));
+            _toolSizeSetting = Toolbar.GetSetting<int>("ToolSize");
         }
 
         public override LayerChange[] Use(Layer layer, Coordinates[] coordinates, Color color)
         {
             Coordinates startingCords = coordinates.Length > 1 ? coordinates[1] : coordinates[0];
-            var pixels = Draw(startingCords, coordinates[0], color, (int) Toolbar.Settings[_toolSizeIndex].Value);
+            var pixels = Draw(startingCords, coordinates[0], color, _toolSizeSetting.Value);
             return Only(pixels, layer);
         }
 

--- a/PixiEditor/Models/Tools/Tools/PenTool.cs
+++ b/PixiEditor/Models/Tools/Tools/PenTool.cs
@@ -11,14 +11,14 @@ namespace PixiEditor.Models.Tools.Tools
     public class PenTool : BitmapOperationTool
     {
         public override ToolType ToolType => ToolType.Pen;
-        private readonly Setting<int> _toolSizeSetting;
+        private readonly SizeSetting _toolSizeSetting;
 
         public PenTool()
         {
             Cursor = Cursors.Pen;
             Tooltip = "Standard brush (B)";
             Toolbar = new BasicToolbar();
-            _toolSizeSetting = Toolbar.GetSetting<int>("ToolSize");
+            _toolSizeSetting = Toolbar.GetSetting<SizeSetting>("ToolSize");
         }
 
         public override LayerChange[] Use(Layer layer, Coordinates[] coordinates, Color color)

--- a/PixiEditor/Models/Tools/Tools/RectangleTool.cs
+++ b/PixiEditor/Models/Tools/Tools/RectangleTool.cs
@@ -21,12 +21,12 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override LayerChange[] Use(Layer layer, Coordinates[] coordinates, Color color)
         {
-            int thickness = (int) Toolbar.GetSetting("ToolSize").Value;
+            int thickness = Toolbar.GetSetting<int>("ToolSize").Value;
             BitmapPixelChanges pixels =
                 BitmapPixelChanges.FromSingleColoredArray(CreateRectangle(coordinates, thickness), color);
-            if ((bool) Toolbar.GetSetting("Fill").Value)
+            if (Toolbar.GetSetting<bool>("Fill").Value)
             {
-                Color fillColor = (Color) Toolbar.GetSetting("FillColor").Value;
+                Color fillColor = Toolbar.GetSetting<Color>("FillColor").Value;
                 pixels.ChangedPixels.AddRangeOverride(
                     BitmapPixelChanges.FromSingleColoredArray
                             (CalculateFillForRectangle(coordinates[^1], coordinates[0], thickness), fillColor)

--- a/PixiEditor/Models/Tools/Tools/RectangleTool.cs
+++ b/PixiEditor/Models/Tools/Tools/RectangleTool.cs
@@ -6,6 +6,7 @@ using PixiEditor.Helpers.Extensions;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 
 namespace PixiEditor.Models.Tools.Tools
 {
@@ -21,12 +22,12 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override LayerChange[] Use(Layer layer, Coordinates[] coordinates, Color color)
         {
-            int thickness = Toolbar.GetSetting<int>("ToolSize").Value;
+            int thickness = Toolbar.GetSetting<SizeSetting>("ToolSize").Value;
             BitmapPixelChanges pixels =
                 BitmapPixelChanges.FromSingleColoredArray(CreateRectangle(coordinates, thickness), color);
-            if (Toolbar.GetSetting<bool>("Fill").Value)
+            if (Toolbar.GetSetting<BoolSetting>("Fill").Value)
             {
-                Color fillColor = Toolbar.GetSetting<Color>("FillColor").Value;
+                Color fillColor = Toolbar.GetSetting<ColorSetting>("FillColor").Value;
                 pixels.ChangedPixels.AddRangeOverride(
                     BitmapPixelChanges.FromSingleColoredArray
                             (CalculateFillForRectangle(coordinates[^1], coordinates[0], thickness), fillColor)

--- a/PixiEditor/Models/Tools/Tools/SelectTool.cs
+++ b/PixiEditor/Models/Tools/Tools/SelectTool.cs
@@ -7,6 +7,7 @@ using PixiEditor.Models.Controllers;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Enums;
 using PixiEditor.Models.Position;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 using PixiEditor.Models.Tools.ToolSettings.Toolbars;
 using PixiEditor.ViewModels;
 
@@ -26,7 +27,7 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override void OnMouseDown(MouseEventArgs e)
         {
-            Enum.TryParse(Toolbar.GetSetting<ComboBoxItem>("Mode")?.Value?.Content as string, out SelectionType);
+            Enum.TryParse((Toolbar.GetSetting<DropdownSetting>("Mode")?.Value as ComboBoxItem)?.Content as string, out SelectionType);
 
             _oldSelection = null;
             if (ViewModelMain.Current.ActiveSelection != null &&

--- a/PixiEditor/Models/Tools/Tools/SelectTool.cs
+++ b/PixiEditor/Models/Tools/Tools/SelectTool.cs
@@ -26,7 +26,7 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override void OnMouseDown(MouseEventArgs e)
         {
-            Enum.TryParse((Toolbar.GetSetting<object>("Mode").Value as ComboBoxItem)?.Content as string, out SelectionType);
+            Enum.TryParse(Toolbar.GetSetting<ComboBoxItem>("Mode")?.Value?.Content as string, out SelectionType);
 
             _oldSelection = null;
             if (ViewModelMain.Current.ActiveSelection != null &&

--- a/PixiEditor/Models/Tools/Tools/SelectTool.cs
+++ b/PixiEditor/Models/Tools/Tools/SelectTool.cs
@@ -6,7 +6,6 @@ using System.Windows.Input;
 using PixiEditor.Models.Controllers;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Enums;
-using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
 using PixiEditor.Models.Tools.ToolSettings.Toolbars;
 using PixiEditor.ViewModels;
@@ -27,7 +26,7 @@ namespace PixiEditor.Models.Tools.Tools
 
         public override void OnMouseDown(MouseEventArgs e)
         {
-            Enum.TryParse((Toolbar.GetSetting("Mode").Value as ComboBoxItem)?.Content as string, out SelectionType);
+            Enum.TryParse((Toolbar.GetSetting<object>("Mode").Value as ComboBoxItem)?.Content as string, out SelectionType);
 
             _oldSelection = null;
             if (ViewModelMain.Current.ActiveSelection != null &&

--- a/PixiEditorTests/ModelsTests/ToolsTests/ToolbarTests/ToolbarBaseTests.cs
+++ b/PixiEditorTests/ModelsTests/ToolsTests/ToolbarTests/ToolbarBaseTests.cs
@@ -7,7 +7,6 @@ namespace PixiEditorTests.ModelsTests.ToolsTests.ToolbarTests
     [Collection("Application collection")]
     public class ToolbarBaseTests
     {
-
         [StaFact]
         public void TestThatGetSettingReturnsCorrectSetting()
         {
@@ -18,6 +17,21 @@ namespace PixiEditorTests.ModelsTests.ToolsTests.ToolbarTests
 
             Assert.NotNull(setting);
             Assert.Equal(settingName,setting.Name);
+        }
+
+        [StaFact]
+        public void TestThatGetSettingReturnsSettingWithCorrectType()
+        {
+            const string settingName = "test";
+            const bool settingValue = true;
+            Setting<bool> expected = new BoolSetting(settingName, settingValue);
+
+            BasicToolbar toolbar = new BasicToolbar();
+            toolbar.Settings.Add(expected);
+
+            Setting<bool> actual = toolbar.GetSetting<bool>(settingName);
+
+            Assert.Equal(expected.Value, actual.Value);
         }
 
         [StaFact]

--- a/PixiEditorTests/ModelsTests/ToolsTests/ToolbarTests/ToolbarBaseTests.cs
+++ b/PixiEditorTests/ModelsTests/ToolsTests/ToolbarTests/ToolbarBaseTests.cs
@@ -29,7 +29,7 @@ namespace PixiEditorTests.ModelsTests.ToolsTests.ToolbarTests
             BasicToolbar toolbar = new BasicToolbar();
             toolbar.Settings.Add(expected);
 
-            Setting<bool> actual = toolbar.GetSetting<bool>(settingName);
+            BoolSetting actual = toolbar.GetSetting<BoolSetting>(settingName);
 
             Assert.Equal(expected.Value, actual.Value);
         }
@@ -39,19 +39,19 @@ namespace PixiEditorTests.ModelsTests.ToolsTests.ToolbarTests
         {
             BasicToolbar toolbar = new BasicToolbar();
 
-            Setting<bool> actual = toolbar.GetSetting<bool>("invalid");
+            BoolSetting actual = toolbar.GetSetting<BoolSetting>("invalid");
 
             Assert.Null(actual);
         }
 
         [StaFact]
-        public void TestThatGenericGetSettingReturnsNullWhenSettingHasValueWithWrongType()
+        public void TestThatGenericGetSettingReturnsNullWhenSettingHasWrongType()
         {
             const string settingName = "test";
             BasicToolbar toolbar = new BasicToolbar();
             toolbar.Settings.Add(new BoolSetting(settingName));
 
-            Setting<int> actual = toolbar.GetSetting<int>(settingName);
+            SizeSetting actual = toolbar.GetSetting<SizeSetting>(settingName);
 
             Assert.Null(actual);
         }
@@ -61,17 +61,17 @@ namespace PixiEditorTests.ModelsTests.ToolsTests.ToolbarTests
         {
             BasicToolbar toolbar = new BasicToolbar();
 
-            toolbar.GetSetting<int>("ToolSize").Value = 5;
+            toolbar.GetSetting<SizeSetting>("ToolSize").Value = 5;
 
             toolbar.SaveToolbarSettings();
 
             BasicShapeToolbar shapeToolbar = new BasicShapeToolbar();
 
-            Assert.NotEqual(5, shapeToolbar.GetSetting<int>("ToolSize").Value);
+            Assert.NotEqual(5, shapeToolbar.GetSetting<SizeSetting>("ToolSize").Value);
 
             shapeToolbar.LoadSharedSettings();
 
-            Assert.Equal(5, shapeToolbar.GetSetting<int>("ToolSize").Value);
+            Assert.Equal(5, shapeToolbar.GetSetting<SizeSetting>("ToolSize").Value);
         }
     }
 }

--- a/PixiEditorTests/ModelsTests/ToolsTests/ToolbarTests/ToolbarBaseTests.cs
+++ b/PixiEditorTests/ModelsTests/ToolsTests/ToolbarTests/ToolbarBaseTests.cs
@@ -20,7 +20,7 @@ namespace PixiEditorTests.ModelsTests.ToolsTests.ToolbarTests
         }
 
         [StaFact]
-        public void TestThatGetSettingReturnsSettingWithCorrectType()
+        public void TestThatGenericGetSettingReturnsSettingWithCorrectType()
         {
             const string settingName = "test";
             const bool settingValue = true;
@@ -32,6 +32,28 @@ namespace PixiEditorTests.ModelsTests.ToolsTests.ToolbarTests
             Setting<bool> actual = toolbar.GetSetting<bool>(settingName);
 
             Assert.Equal(expected.Value, actual.Value);
+        }
+
+        [StaFact]
+        public void TestThatGenericGetSettingReturnsNullWhenSettingIsNotFound()
+        {
+            BasicToolbar toolbar = new BasicToolbar();
+
+            Setting<bool> actual = toolbar.GetSetting<bool>("invalid");
+
+            Assert.Null(actual);
+        }
+
+        [StaFact]
+        public void TestThatGenericGetSettingReturnsNullWhenSettingHasValueWithWrongType()
+        {
+            const string settingName = "test";
+            BasicToolbar toolbar = new BasicToolbar();
+            toolbar.Settings.Add(new BoolSetting(settingName));
+
+            Setting<int> actual = toolbar.GetSetting<int>(settingName);
+
+            Assert.Null(actual);
         }
 
         [StaFact]

--- a/PixiEditorTests/ModelsTests/ToolsTests/ToolbarTests/ToolbarBaseTests.cs
+++ b/PixiEditorTests/ModelsTests/ToolsTests/ToolbarTests/ToolbarBaseTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using PixiEditor.Models.Tools.ToolSettings;
-using PixiEditor.Models.Tools.ToolSettings.Settings;
+﻿using PixiEditor.Models.Tools.ToolSettings.Settings;
 using PixiEditor.Models.Tools.ToolSettings.Toolbars;
 using Xunit;
 
@@ -29,17 +25,17 @@ namespace PixiEditorTests.ModelsTests.ToolsTests.ToolbarTests
         {
             BasicToolbar toolbar = new BasicToolbar();
 
-            toolbar.Settings[0].Value = 5;
+            toolbar.GetSetting<int>("ToolSize").Value = 5;
 
             toolbar.SaveToolbarSettings();
 
             BasicShapeToolbar shapeToolbar = new BasicShapeToolbar();
 
-            Assert.NotEqual(5, (int)shapeToolbar.GetSetting("ToolSize").Value);
+            Assert.NotEqual(5, shapeToolbar.GetSetting<int>("ToolSize").Value);
 
             shapeToolbar.LoadSharedSettings();
 
-            Assert.Equal(5, (int)shapeToolbar.GetSetting("ToolSize").Value);
+            Assert.Equal(5, shapeToolbar.GetSetting<int>("ToolSize").Value);
         }
     }
 }

--- a/PixiEditorTests/ModelsTests/ToolsTests/ToolbarTests/ToolbarBaseTests.cs
+++ b/PixiEditorTests/ModelsTests/ToolsTests/ToolbarTests/ToolbarBaseTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using PixiEditor.Models.Tools.ToolSettings;
+using PixiEditor.Models.Tools.ToolSettings.Settings;
 using PixiEditor.Models.Tools.ToolSettings.Toolbars;
 using Xunit;
 


### PR DESCRIPTION
 ## Pull Requests

 Pull request rules:

 1. Clearly describe changes, as detailed as possible

I created the Setting<T> class as an inheritor of Setting. I moved the Value property and associated field to the Setting<T> in order to have the generic Value.

I inherited other settings from Setting<T> where possible.

I added Toolbar.GetSettings<T> method in order to get a generic Setting where it is required. In addition, I used this method in places where the (some type) casts were placed.

One of the biggest problems was to refactor the SaveToolbarSettings and LoadSharedSettings methods. They were using the Setting.Value property but all the settings are cast to the base class. So, there is no information about the type of value and it breaks the idea of generic usage. I got rid of using Value property - instead, I just re-insert the record to the collection if this record was already inserted.

Also, I covered the Toolbar.GetSettings<T> by tests. Maybe, some more tests are required- it is ok to write to me about it, I will try to cover as much of my changes as needed.

During the manual testing, I have gotten the Null-pointer exception couple of times, though all tests were green. I have tried to find and fix all of those NPE places, but I still might miss some of them.


 2. If possible, show examples of usage

I think the usage of Toolbar.GetSetting<T>(settingName) is the best example, you can find some of them in changed files

 3. Ensure any install or build dependencies are removed before the end of the layer when doing a build.

I haven`t added any dependencies

 4. Make sure all tests are passing.

All tests are green on my machine.
