### PR TITLE
Pixel layers multiplication hotfix

### DIFF
--- a/PixiEditor/Models/ImageManipulation/BitmapUtils.cs
+++ b/PixiEditor/Models/ImageManipulation/BitmapUtils.cs
@@ -41,13 +41,25 @@ namespace PixiEditor.Models.ImageManipulation
             using (finalBitmap.GetBitmapContext())
             {
                 for (int i = 0; i < layers.Length; i++)
-                for (int y = 0; y < finalBitmap.Height; y++)
-                for (int x = 0; x < finalBitmap.Width; x++)
-                {
-                    Color color = layers[i].GetPixelWithOffset(x, y);
-                    color = Color.FromArgb((byte)(color.A * layers[i].Opacity), color.R,color.G, color.B);
-                    if (color.A != 0 || color.R != 0 || color.B != 0 || color.G != 0) finalBitmap.SetPixel(x, y, color);
-                }
+                    for (int y = 0; y < finalBitmap.Height; y++)
+                        for (int x = 0; x < finalBitmap.Width; x++)
+                        {
+                            Color color = layers[i].GetPixelWithOffset(x, y);
+                            if (i > 0 && color.A < 255)
+                            {
+                                var lastLayerPixel = layers[i - 1].GetPixelWithOffset(x, y);
+                                byte r = (byte)((color.R * color.A / 255) + (lastLayerPixel.R * lastLayerPixel.A * (255 - color.A) / (255 * 255)));
+                                byte g = (byte)((color.G * color.A / 255) + (lastLayerPixel.G * lastLayerPixel.A * (255 - color.A) / (255 * 255)));
+                                byte b = (byte)((color.B * color.A / 255) + (lastLayerPixel.B * lastLayerPixel.A * (255 - color.A) / (255 * 255)));
+                                byte a = (byte)(color.A + (lastLayerPixel.A * (255 - color.A) / 255));
+                                color = Color.FromArgb((byte)(a * layers[i].Opacity), r, g, b);
+                            }
+                            else
+                            {
+                                color = Color.FromArgb((byte)(color.A * layers[i].Opacity), color.R, color.G, color.B);
+                            }
+                            if (color.A != 0 || color.R != 0 || color.B != 0 || color.G != 0) finalBitmap.SetPixel(x, y, color);
+                        }
             }
 
             return finalBitmap;

--- a/windows-x64-release.yml
+++ b/windows-x64-release.yml
@@ -5,7 +5,7 @@
 
 trigger:
 - release
-- cd-azure-pipelines
+  pr: none
 
 pool:
   vmImage: 'windows-latest'

--- a/windows-x64-release.yml
+++ b/windows-x64-release.yml
@@ -5,7 +5,8 @@
 
 trigger:
 - release
-  pr: none
+
+pr: none
 
 pool:
   vmImage: 'windows-latest'

--- a/windows-x86-release.yml
+++ b/windows-x86-release.yml
@@ -5,7 +5,7 @@
 
 trigger:
 - release
-- cd-azure-pipelines
+  pr: none
 
 pool:
   vmImage: 'windows-latest'

--- a/windows-x86-release.yml
+++ b/windows-x86-release.yml
@@ -5,7 +5,7 @@
 
 trigger:
 - release
-  pr: none
+pr: none
 
 pool:
   vmImage: 'windows-latest'


### PR DESCRIPTION
Fixed exporting pixels that use non 255 alpha, now they are combined correctly.