### PR TITLE
Optimize FloodFill

### DIFF
--- a/PixiEditor/Models/Tools/Tools/FloodFill.cs
+++ b/PixiEditor/Models/Tools/Tools/FloodFill.cs
@@ -24,8 +24,8 @@ namespace PixiEditor.Models.Tools.Tools
         {
             List<Coordinates> changedCoords = new List<Coordinates>();
 
-            int width = layer.Width;
-            int height = layer.Height;
+            int width = ViewModelMain.Current.BitmapManager.ActiveDocument.Width;
+            int height = ViewModelMain.Current.BitmapManager.ActiveDocument.Height;
 
             var visited = new bool[width, height];
 

--- a/PixiEditor/Models/Tools/Tools/FloodFill.cs
+++ b/PixiEditor/Models/Tools/Tools/FloodFill.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
-using PixiEditor.ViewModels;
 
 namespace PixiEditor.Models.Tools.Tools
 {
@@ -23,42 +20,41 @@ namespace PixiEditor.Models.Tools.Tools
             return Only(ForestFire(layer, coordinates[0], color), layer);
         }
 
-        public BitmapPixelChanges ForestFire(Layer layer, Coordinates startingCoords, Color newColor)
+        private BitmapPixelChanges ForestFire(Layer layer, Coordinates startingCoords, Color newColor)
         {
             List<Coordinates> changedCoords = new List<Coordinates>();
 
-            Layer clone = layer.Clone();
-            int width = ViewModelMain.Current.BitmapManager.ActiveDocument.Width;
-            int height = ViewModelMain.Current.BitmapManager.ActiveDocument.Height;
+            int width = layer.Width;
+            int height = layer.Height;
+
+            var visited = new bool[width, height];
 
             Color colorToReplace = layer.GetPixelWithOffset(startingCoords.X, startingCoords.Y);
 
             var stack = new Stack<Coordinates>();
             stack.Push(new Coordinates(startingCoords.X, startingCoords.Y));
-            
-            using(clone.LayerBitmap.GetBitmapContext(ReadWriteMode.ReadWrite))
+
+            while (stack.Count > 0)
             {
-                while (stack.Count > 0)
+                var cords = stack.Pop();
+                var relativeCords = layer.GetRelativePosition(cords);
+
+                if (cords.X < 0 || cords.X > width - 1) continue;
+                if (cords.Y < 0 || cords.Y > height - 1) continue;
+                if (visited[cords.X, cords.Y]) continue;
+                if (layer.GetPixel(relativeCords.X, relativeCords.Y) == newColor) continue;
+
+                if (layer.GetPixel(relativeCords.X, relativeCords.Y) == colorToReplace)
                 {
-                    var cords = stack.Pop();
-                    var relativeCords = clone.GetRelativePosition(cords);
-
-                    if (cords.X < 0 || cords.X > width - 1) continue;
-                    if (cords.Y < 0 || cords.Y > height - 1) continue;
-                    if (clone.GetPixel(relativeCords.X, relativeCords.Y) == newColor) continue;
-
-                    if (clone.GetPixel(relativeCords.X, relativeCords.Y) == colorToReplace)
-                    {
-                        changedCoords.Add(new Coordinates(cords.X, cords.Y));
-                        clone.SetPixel(new Coordinates(cords.X, cords.Y), newColor);
-                        stack.Push(new Coordinates(cords.X, cords.Y - 1));
-                        stack.Push(new Coordinates(cords.X + 1, cords.Y));
-                        stack.Push(new Coordinates(cords.X, cords.Y + 1));
-                        stack.Push(new Coordinates(cords.X - 1, cords.Y));
-                    }
+                    changedCoords.Add(new Coordinates(cords.X, cords.Y));
+                    visited[cords.X, cords.Y] = true;
+                    stack.Push(new Coordinates(cords.X, cords.Y - 1));                    
+                    stack.Push(new Coordinates(cords.X, cords.Y + 1));                    
+                    stack.Push(new Coordinates(cords.X - 1, cords.Y));
+                    stack.Push(new Coordinates(cords.X + 1, cords.Y));
                 }
-
             }
+
             return BitmapPixelChanges.FromSingleColoredArray(changedCoords, newColor);
         }
     }

--- a/PixiEditor/Models/Tools/Tools/FloodFill.cs
+++ b/PixiEditor/Models/Tools/Tools/FloodFill.cs
@@ -3,6 +3,7 @@ using System.Windows.Media;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
+using PixiEditor.ViewModels;
 
 namespace PixiEditor.Models.Tools.Tools
 {


### PR DESCRIPTION
Resolves #34 

I've run test benchmark on 1024x1024 bitmap with a circle of 384px radius as fill target.

All the changes mentioned in Reddit post are implemented.

The only other significant performance boost would be to parallelize bitmap traversal, but since in WPF bitmaps have thread affinity, it would require cloning whole bitmap...

### Before

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1082 (1909/November2018Update/19H2)
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.402
  [Host]        : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  .NET Core 3.1 : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT

Job=.NET Core 3.1  Runtime=.NET Core 3.1  

```
|        Method |    Mean |    Error |   StdDev |     Min |     Max |  Median |
|-------------- |--------:|---------:|---------:|--------:|--------:|--------:|
| FloodFillTest | 1.298 s | 0.0038 s | 0.0036 s | 1.291 s | 1.304 s | 1.298 s |

### After

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1082 (1909/November2018Update/19H2)
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.402
  [Host]        : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  .NET Core 3.1 : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT

Job=.NET Core 3.1  Runtime=.NET Core 3.1  

```
|        Method |    Mean |    Error |   StdDev |     Min |     Max |  Median |
|-------------- |--------:|---------:|---------:|--------:|--------:|--------:|
| FloodFillTest | 1.016 s | 0.0064 s | 0.0057 s | 1.005 s | 1.027 s | 1.016 s |


