### PR TITLE
Added null check

### DIFF
--- a/PixiEditor/ViewModels/SubViewModels/Main/IoViewModel.cs
+++ b/PixiEditor/ViewModels/SubViewModels/Main/IoViewModel.cs
@@ -80,7 +80,7 @@ namespace PixiEditor.ViewModels.SubViewModels.Main
 
         private void MouseDown(object parameter)
         {
-            if (Owner.BitmapManager.ActiveDocument.Layers.Count == 0)
+            if (Owner.BitmapManager.ActiveDocument == null || Owner.BitmapManager.ActiveDocument.Layers.Count == 0)
             {
                 return;
             }


### PR DESCRIPTION
Before checking if the `ActiveDocument` is null it threw a `NullRefrenceException` when checking if the Layer Count is zero