### PR TITLE
Added clipboard undo support

### DIFF
--- a/PixiEditor/Models/Controllers/BitmapManager.cs
+++ b/PixiEditor/Models/Controllers/BitmapManager.cs
@@ -248,7 +248,7 @@ namespace PixiEditor.Models.Controllers
             SelectedTool.OnStoppedRecordingMouseUp(new MouseEventArgs(Mouse.PrimaryDevice, (int)DateTimeOffset.UtcNow.ToUnixTimeSeconds()));
             if (IsOperationTool(SelectedTool) && ((BitmapOperationTool)SelectedTool).RequiresPreviewLayer)
             {
-                BitmapOperations.StopAction();
+                BitmapOperations.ApplyPreviewLayer();
             }
         }
 

--- a/PixiEditor/Models/Controllers/BitmapOperationsUtility.cs
+++ b/PixiEditor/Models/Controllers/BitmapOperationsUtility.cs
@@ -35,9 +35,10 @@ namespace PixiEditor.Models.Controllers
             LayerChange[] newChange = new LayerChange[layers.Length];
             for (int i = 0; i < layers.Length; i++)
             {
+                int indexOfLayer = Manager.ActiveDocument.Layers.IndexOf(layers[i]);
                 old[i] = new LayerChange(
-                    BitmapPixelChanges.FromArrays(pixels, oldValues[layers[i]]), i);
-                newChange[i] = new LayerChange(changes, i);
+                    BitmapPixelChanges.FromArrays(pixels, oldValues[layers[i]]), indexOfLayer);
+                newChange[i] = new LayerChange(changes, indexOfLayer);
                 layers[i].SetPixels(changes);
             }
 

--- a/PixiEditor/Models/Controllers/BitmapOperationsUtility.cs
+++ b/PixiEditor/Models/Controllers/BitmapOperationsUtility.cs
@@ -29,6 +29,11 @@ namespace PixiEditor.Models.Controllers
 
         public void DeletePixels(Layer[] layers, Coordinates[] pixels)
         {
+            if (Manager.ActiveDocument == null)
+            {
+                return;
+            }
+
             BitmapPixelChanges changes = BitmapPixelChanges.FromSingleColoredArray(pixels, Color.FromArgb(0, 0, 0, 0));
             Dictionary<Layer, Color[]> oldValues = BitmapUtils.GetPixelsForSelection(layers, pixels);
             LayerChange[] old = new LayerChange[layers.Length];

--- a/PixiEditor/Models/Controllers/BitmapOperationsUtility.cs
+++ b/PixiEditor/Models/Controllers/BitmapOperationsUtility.cs
@@ -69,7 +69,7 @@ namespace PixiEditor.Models.Controllers
         /// <summary>
         ///     Applies pixels from preview layer to selected layer.
         /// </summary>
-        public void StopAction()
+        public void ApplyPreviewLayer()
         {
             if (lastModifiedLayers == null)
             {

--- a/PixiEditor/Models/Controllers/ClipboardController.cs
+++ b/PixiEditor/Models/Controllers/ClipboardController.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Windows;
 using System.Windows.Media.Imaging;
+using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.ImageManipulation;
 using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
@@ -44,7 +45,30 @@ namespace PixiEditor.Models.Controllers
             if (image != null)
             {
                 AddImageToLayers(image);
+                int latestLayerIndex = ViewModelMain.Current.BitmapManager.ActiveDocument.Layers.Count - 1;
+                UndoManager.AddUndoChange(
+                    new Change(RemoveLayerProcess, new object[] { latestLayerIndex }, AddLayerProcess, new object[] { image }));
             }
+        }
+
+        private static void RemoveLayerProcess(object[] parameters)
+        {
+            if (parameters.Length == 0 || !(parameters[0] is int))
+            {
+                return;
+            }
+
+            ViewModelMain.Current.BitmapManager.RemoveLayer((int)parameters[0]);
+        }
+
+        private static void AddLayerProcess(object[] parameters)
+        {
+            if (parameters.Length == 0 || !(parameters[0] is WriteableBitmap))
+            {
+                return;
+            }
+
+            AddImageToLayers((WriteableBitmap)parameters[0]);
         }
 
         /// <summary>

--- a/PixiEditor/Models/Controllers/UndoManager.cs
+++ b/PixiEditor/Models/Controllers/UndoManager.cs
@@ -32,13 +32,14 @@ namespace PixiEditor.Models.Controllers
         /// </summary>
         public static void AddUndoChange(Change change)
         {
-            // Clears RedoStack if las move wasn't redo or undo and if redo stack is greater than 0
+            lastChangeWasUndo = false;
+
+            // Clears RedoStack if last move wasn't redo or undo and if redo stack is greater than 0.
             if (lastChangeWasUndo == false && RedoStack.Count > 0)
             {
                 RedoStack.Clear();
             }
 
-            lastChangeWasUndo = false;
             change.Root ??= MainRoot;
             UndoStack.Push(change);
         }

--- a/PixiEditor/Models/DataHolders/BitmapPixelChanges.cs
+++ b/PixiEditor/Models/DataHolders/BitmapPixelChanges.cs
@@ -41,26 +41,6 @@ namespace PixiEditor.Models.DataHolders
         }
 
         /// <summary>
-        ///     Builds BitmapPixelChanges from coordinates in layer.
-        /// </summary>
-        /// <param name="selectedPoints">Pixels coordinates in layer.</param>
-        /// <param name="activeLayer">Layer from pixels are taken.</param>
-        /// <returns>BitmapPixelChanges.</returns>
-        public static BitmapPixelChanges FromSelection(IEnumerable<Coordinates> selectedPoints, Layer activeLayer)
-        {
-            Dictionary<Coordinates, Color> dict = new Dictionary<Coordinates, Color>();
-            using (var ctx = activeLayer.LayerBitmap.GetBitmapContext())
-            {
-                foreach (var point in selectedPoints)
-                {
-                    dict.Add(point, ctx.WriteableBitmap.GetPixel(point.X, point.Y));
-                }
-            }
-
-            return new BitmapPixelChanges(dict);
-        }
-
-        /// <summary>
         ///     Combines pixel changes array with overriding values.
         /// </summary>
         /// <param name="changes">BitmapPixelChanges to combine.</param>

--- a/PixiEditor/Models/DataHolders/BitmapPixelChanges.cs
+++ b/PixiEditor/Models/DataHolders/BitmapPixelChanges.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using PixiEditor.Exceptions;
 using PixiEditor.Helpers.Extensions;
+using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
 
 namespace PixiEditor.Models.DataHolders
@@ -35,6 +38,26 @@ namespace PixiEditor.Models.DataHolders
             }
 
             return new BitmapPixelChanges(dict) { WasBuiltAsSingleColored = true };
+        }
+
+        /// <summary>
+        ///     Builds BitmapPixelChanges from coordinates in layer.
+        /// </summary>
+        /// <param name="selectedPoints">Pixels coordinates in layer.</param>
+        /// <param name="activeLayer">Layer from pixels are taken.</param>
+        /// <returns>BitmapPixelChanges.</returns>
+        public static BitmapPixelChanges FromSelection(IEnumerable<Coordinates> selectedPoints, Layer activeLayer)
+        {
+            Dictionary<Coordinates, Color> dict = new Dictionary<Coordinates, Color>();
+            using (var ctx = activeLayer.LayerBitmap.GetBitmapContext())
+            {
+                foreach (var point in selectedPoints)
+                {
+                    dict.Add(point, ctx.WriteableBitmap.GetPixel(point.X, point.Y));
+                }
+            }
+
+            return new BitmapPixelChanges(dict);
         }
 
         /// <summary>

--- a/PixiEditor/Models/Tools/Tools/PenTool.cs
+++ b/PixiEditor/Models/Tools/Tools/PenTool.cs
@@ -5,6 +5,7 @@ using PixiEditor.Models.Layers;
 using PixiEditor.Models.Position;
 using PixiEditor.Models.Tools.ToolSettings.Settings;
 using PixiEditor.Models.Tools.ToolSettings.Toolbars;
+using PixiEditor.ViewModels;
 
 namespace PixiEditor.Models.Tools.Tools
 {

--- a/PixiEditor/Models/Tools/Tools/SelectTool.cs
+++ b/PixiEditor/Models/Tools/Tools/SelectTool.cs
@@ -49,7 +49,8 @@ namespace PixiEditor.Models.Tools.Tools
                 ViewModelMain.Current.SelectionSubViewModel.ActiveSelection.Clear();
             }
 
-            UndoManager.AddUndoChange(new Change("ActiveSelection", oldSelection, ViewModelMain.Current.SelectionSubViewModel.ActiveSelection, "Select pixels"));
+            UndoManager.AddUndoChange(
+                new Change("ActiveSelection", oldSelection, ViewModelMain.Current.SelectionSubViewModel.ActiveSelection, "Select pixels", ViewModelMain.Current.SelectionSubViewModel));
         }
 
         public override void Use(Coordinates[] pixels)

--- a/PixiEditor/ViewModels/SubViewModels/Main/ClipboardViewModel.cs
+++ b/PixiEditor/ViewModels/SubViewModels/Main/ClipboardViewModel.cs
@@ -37,10 +37,12 @@ namespace PixiEditor.ViewModels.SubViewModels.Main
         public void Cut(object parameter)
         {
             Copy(null);
-            Owner.BitmapManager.ActiveLayer.SetPixels(
+            Owner.BitmapManager.ActiveDocument.ActiveLayer.SetPixels(
                 BitmapPixelChanges.FromSingleColoredArray(
                     Owner.SelectionSubViewModel.ActiveSelection.SelectedPoints.ToArray(),
                     Colors.Transparent));
+            LayerChange[] oldValues = new 
+            UndoManager.AddUndoChange(new Change("UndoChanges", oldValues, newValues, description: "Cut selection"));
         }
 
         public void Paste(object parameter)

--- a/PixiEditor/ViewModels/SubViewModels/Main/ClipboardViewModel.cs
+++ b/PixiEditor/ViewModels/SubViewModels/Main/ClipboardViewModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Media;
 using PixiEditor.Helpers;
 using PixiEditor.Models.Controllers;
 using PixiEditor.Models.DataHolders;
+using PixiEditor.Models.Position;
 
 namespace PixiEditor.ViewModels.SubViewModels.Main
 {
@@ -37,12 +38,9 @@ namespace PixiEditor.ViewModels.SubViewModels.Main
         public void Cut(object parameter)
         {
             Copy(null);
-            Owner.BitmapManager.ActiveDocument.ActiveLayer.SetPixels(
-                BitmapPixelChanges.FromSingleColoredArray(
-                    Owner.SelectionSubViewModel.ActiveSelection.SelectedPoints.ToArray(),
-                    Colors.Transparent));
-            LayerChange[] oldValues = new 
-            UndoManager.AddUndoChange(new Change("UndoChanges", oldValues, newValues, description: "Cut selection"));
+            Owner.BitmapManager.BitmapOperations.DeletePixels(
+                new[] { Owner.BitmapManager.ActiveDocument.ActiveLayer },
+                Owner.SelectionSubViewModel.ActiveSelection.SelectedPoints.ToArray());
         }
 
         public void Paste(object parameter)
@@ -58,7 +56,7 @@ namespace PixiEditor.ViewModels.SubViewModels.Main
         private void Copy(object parameter)
         {
             ClipboardController.CopyToClipboard(
-                Owner.BitmapManager.ActiveDocument.Layers.ToArray(),
+                new[] { Owner.BitmapManager.ActiveDocument.ActiveLayer },
                 Owner.SelectionSubViewModel.ActiveSelection.SelectedPoints.ToArray(),
                 Owner.BitmapManager.ActiveDocument.Width,
                 Owner.BitmapManager.ActiveDocument.Height);

--- a/PixiEditor/ViewModels/SubViewModels/Main/UndoViewModel.cs
+++ b/PixiEditor/ViewModels/SubViewModels/Main/UndoViewModel.cs
@@ -33,6 +33,7 @@ namespace PixiEditor.ViewModels.SubViewModels.Main
         {
             UndoCommand = new RelayCommand(Undo, CanUndo);
             RedoCommand = new RelayCommand(Redo, CanRedo);
+            UndoManager.SetMainRoot(this);
         }
 
         public void TriggerNewUndoChange(Tool toolUsed)

--- a/PixiEditor/ViewModels/ViewModelMain.cs
+++ b/PixiEditor/ViewModels/ViewModelMain.cs
@@ -133,7 +133,6 @@ namespace PixiEditor.ViewModels
                     new Shortcut(Key.N, FileSubViewModel.OpenNewFilePopupCommand, modifier: ModifierKeys.Control)
                 }
             };
-            UndoManager.SetMainRoot(this);
             BitmapManager.PrimaryColor = ColorsSubViewModel.PrimaryColor;
             Current = this;
         }

--- a/PixiEditorTests/ModelsTests/ControllersTests/BitmapOperationsUtilityTests.cs
+++ b/PixiEditorTests/ModelsTests/ControllersTests/BitmapOperationsUtilityTests.cs
@@ -14,6 +14,7 @@ namespace PixiEditorTests.ModelsTests.ControllersTests
         public void TestThatBitmapOperationsUtilityDeletesPixels()
         {
             BitmapOperationsUtility util = new BitmapOperationsUtility(new BitmapManager());
+            util.Manager.ActiveDocument = new Document(10, 10);
 
             Layer testLayer = new Layer("test layer", 10, 10);
             Coordinates[] cords = { new Coordinates(0, 0), new Coordinates(1, 1) };

--- a/PixiEditorTests/ViewModelsTests/ViewModelMainTests.cs
+++ b/PixiEditorTests/ViewModelsTests/ViewModelMainTests.cs
@@ -18,7 +18,7 @@ namespace PixiEditorTests.ViewModelsTests
         {
             ViewModelMain viewModel = new ViewModelMain();
 
-            Assert.Equal(viewModel, UndoManager.MainRoot);
+            Assert.Equal(viewModel.UndoSubViewModel, UndoManager.MainRoot);
             Assert.NotNull(viewModel.ChangesController);
             Assert.NotNull(viewModel.ShortcutController);
             Assert.NotEmpty(viewModel.ShortcutController.Shortcuts);


### PR DESCRIPTION
Resolves #92 
Changes:
- Added clipboard undo support
- Added DeletePixels undo support
- Now cut deletes pixels from the selection in the selected layer
- Fixed bug where redo stack didn't reset, while new undo change was added and new undo change was added
- Renamed `StopAction` to `ApplyPreviewLayer`
- Copy now copies selected pixels from the selected layer