### PR TITLE
Fixed removing logical focus from NumberInput

### DIFF
--- a/PixiEditor/Helpers/Behaviours/ClearFocusOnClickBehavior.cs
+++ b/PixiEditor/Helpers/Behaviours/ClearFocusOnClickBehavior.cs
@@ -1,0 +1,25 @@
+﻿using System.Windows;
+using System.Windows.Input;
+using System.Windows.Interactivity;
+
+namespace PixiEditor.Helpers.Behaviours
+{
+    public class ClearFocusOnClickBehavior : Behavior<FrameworkElement>
+    {
+        protected override void OnAttached()
+        {
+            AssociatedObject.MouseDown += AssociatedObject_MouseDown;
+            base.OnAttached();
+        }
+
+        private void AssociatedObject_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            AssociatedObject.Focus();
+        }
+
+        protected override void OnDetaching()
+        {
+            AssociatedObject.MouseDown -= AssociatedObject_MouseDown;
+        }
+    }
+}

--- a/PixiEditor/Helpers/Behaviours/TextBoxFocusBehavior.cs
+++ b/PixiEditor/Helpers/Behaviours/TextBoxFocusBehavior.cs
@@ -54,7 +54,19 @@ namespace PixiEditor.Helpers.Behaviours
             }
 
             ConvertValue();
-            AssociatedObject.MoveFocus(new TraversalRequest(FocusNavigationDirection.Down));
+            RemoveFocus();
+        }
+
+        private void RemoveFocus()
+        {
+            FrameworkElement parent = (FrameworkElement)AssociatedObject.Parent;
+            while (parent != null && parent is IInputElement && !((IInputElement)parent).Focusable)
+            {
+                parent = (FrameworkElement)parent.Parent;
+            }
+
+            DependencyObject scope = FocusManager.GetFocusScope(AssociatedObject);
+            FocusManager.SetFocusedElement(scope, parent);
         }
 
         private void AssociatedObjectGotKeyboardFocus(

--- a/PixiEditor/Helpers/Behaviours/TextBoxFocusBehavior.cs
+++ b/PixiEditor/Helpers/Behaviours/TextBoxFocusBehavior.cs
@@ -60,7 +60,7 @@ namespace PixiEditor.Helpers.Behaviours
         private void RemoveFocus()
         {
             FrameworkElement parent = (FrameworkElement)AssociatedObject.Parent;
-            while (parent != null && parent is IInputElement && !((IInputElement)parent).Focusable)
+            while (parent != null && parent is IInputElement element && !element.Focusable)
             {
                 parent = (FrameworkElement)parent.Parent;
             }

--- a/PixiEditor/Views/Dialogs/ConfirmationPopup.xaml
+++ b/PixiEditor/Views/Dialogs/ConfirmationPopup.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:system="clr-namespace:System;assembly=System.Runtime"
+        xmlns:system="clr-namespace:System;assembly=System.Runtime" xmlns:behaviours="clr-namespace:PixiEditor.Helpers.Behaviours" xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
         mc:Ignorable="d"
         Title="ConfirmationPopup" Name="popup" WindowStartupLocation="CenterScreen" Height="200" Width="500"
         WindowStyle="None">
@@ -13,12 +13,15 @@
                       ResizeBorderThickness="{x:Static SystemParameters.WindowResizeBorderThickness}" />
     </WindowChrome.WindowChrome>
 
-    <Grid Background="{StaticResource AccentColor}">
+    <Grid Background="{StaticResource AccentColor}" Focusable="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="35" />
             <RowDefinition Height="34*" />
             <RowDefinition Height="21*" />
         </Grid.RowDefinitions>
+        <i:Interaction.Behaviors>
+            <behaviours:ClearFocusOnClickBehavior/>
+        </i:Interaction.Behaviors>
         <TextBlock Grid.Row="1" Text="{Binding Body, ElementName=popup}" HorizontalAlignment="Center"
                    VerticalAlignment="Center" FontSize="18" Foreground="White" />
         <DockPanel Grid.Row="0" Background="{StaticResource MainColor}">

--- a/PixiEditor/Views/Dialogs/ImportFilePopup.xaml
+++ b/PixiEditor/Views/Dialogs/ImportFilePopup.xaml
@@ -17,11 +17,14 @@
         <helpers:ToolSizeToIntConverter x:Key="ToolSizeToIntConverter" />
     </Window.Resources>
     <Border BorderBrush="Black" BorderThickness="1">
-        <Grid Background="{StaticResource AccentColor}">
+        <Grid Background="{StaticResource AccentColor}" Focusable="True">
             <Grid.RowDefinitions>
                 <RowDefinition Height="32" />
                 <RowDefinition Height="67*" />
             </Grid.RowDefinitions>
+            <i:Interaction.Behaviors>
+                <behaviors:ClearFocusOnClickBehavior/>
+            </i:Interaction.Behaviors>
             <Grid Grid.Row="0" Background="#FF2C2C2C">
                 <i:Interaction.Triggers>
                     <i:EventTrigger EventName="MouseDown">

--- a/PixiEditor/Views/Dialogs/NewFilePopup.xaml
+++ b/PixiEditor/Views/Dialogs/NewFilePopup.xaml
@@ -17,11 +17,14 @@
         <converters:ToolSizeToIntConverter x:Key="ToolSizeToIntConverter" />
     </Window.Resources>
     <Border BorderBrush="Black" BorderThickness="1">
-        <Grid Background="{StaticResource AccentColor}">
+        <Grid Background="{StaticResource AccentColor}" Focusable="True">
             <Grid.RowDefinitions>
                 <RowDefinition Height="32*" />
                 <RowDefinition Height="577*" />
             </Grid.RowDefinitions>
+            <i:Interaction.Behaviors>
+                <helpers:ClearFocusOnClickBehavior/>
+            </i:Interaction.Behaviors>
             <Grid Grid.Row="0" Background="{StaticResource MainColor}">
                 <i:Interaction.Triggers>
                     <i:EventTrigger EventName="MouseDown">

--- a/PixiEditor/Views/Dialogs/ResizeCanvasPopup.xaml
+++ b/PixiEditor/Views/Dialogs/ResizeCanvasPopup.xaml
@@ -25,12 +25,15 @@
                         Executed="CommandBinding_Executed_Close" />
     </Window.CommandBindings>
 
-    <Grid Background="{StaticResource AccentColor}">
+    <Grid Background="{StaticResource AccentColor}" Focusable="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="35" />
             <RowDefinition />
         </Grid.RowDefinitions>
-
+        <i:Interaction.Behaviors>
+            <behaviors:ClearFocusOnClickBehavior/>
+        </i:Interaction.Behaviors>
+        
         <DockPanel Grid.Row="0" Background="{StaticResource MainColor}">
             <Button DockPanel.Dock="Right" HorizontalAlignment="Right" Style="{StaticResource CloseButtonStyle}"
                     WindowChrome.IsHitTestVisibleInChrome="True" ToolTip="Close"

--- a/PixiEditor/Views/Dialogs/ResizeDocumentPopup.xaml
+++ b/PixiEditor/Views/Dialogs/ResizeDocumentPopup.xaml
@@ -24,12 +24,15 @@
                         Executed="CommandBinding_Executed_Close" />
     </Window.CommandBindings>
 
-    <Grid Background="{StaticResource AccentColor}">
+    <Grid Background="{StaticResource AccentColor}" Focusable="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="35" />
             <RowDefinition />
         </Grid.RowDefinitions>
-
+        <i:Interaction.Behaviors>
+            <behaviors:ClearFocusOnClickBehavior/>
+        </i:Interaction.Behaviors>
+        
         <DockPanel Grid.Row="0" Background="{StaticResource MainColor}">
             <Button DockPanel.Dock="Right" HorizontalAlignment="Right" Style="{StaticResource CloseButtonStyle}"
                     WindowChrome.IsHitTestVisibleInChrome="True" ToolTip="Close"

--- a/PixiEditor/Views/Dialogs/SaveFilePopup.xaml
+++ b/PixiEditor/Views/Dialogs/SaveFilePopup.xaml
@@ -14,11 +14,15 @@
         <helpers1:ToolSizeToIntConverter x:Key="ToolSizeToIntConverter" />
     </Window.Resources>
     <Border BorderBrush="Black" BorderThickness="1">
-        <Grid Background="{StaticResource AccentColor}">
+        <Grid Background="{StaticResource AccentColor}" Focusable="True">
             <Grid.RowDefinitions>
                 <RowDefinition Height="32" />
                 <RowDefinition Height="229*" />
             </Grid.RowDefinitions>
+            <i:Interaction.Behaviors>
+                <helpers:ClearFocusOnClickBehavior/>
+            </i:Interaction.Behaviors>
+            
             <Grid Grid.Row="0" Background="{StaticResource MainColor}">
                 <i:Interaction.Triggers>
                     <i:EventTrigger EventName="MouseDown">

--- a/PixiEditor/Views/Dialogs/SettingsWindow.xaml
+++ b/PixiEditor/Views/Dialogs/SettingsWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:PixiEditor.Views.Dialogs" xmlns:viewmodels="clr-namespace:PixiEditor.ViewModels" xmlns:converters="clr-namespace:PixiEditor.Helpers.Converters" xmlns:views="clr-namespace:PixiEditor.Views"
+        xmlns:local="clr-namespace:PixiEditor.Views.Dialogs" xmlns:viewmodels="clr-namespace:PixiEditor.ViewModels" xmlns:converters="clr-namespace:PixiEditor.Helpers.Converters" xmlns:views="clr-namespace:PixiEditor.Views" xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity" xmlns:behaviours="clr-namespace:PixiEditor.Helpers.Behaviours"
         mc:Ignorable="d"
         Title="Settings" Name="window" 
         Height="450" Width="800" WindowStyle="None" DataContext="{DynamicResource SettingsWindowViewModel}"
@@ -22,7 +22,7 @@
                         Executed="CommandBinding_Executed_Close" />
     </Window.CommandBindings>
 
-    <Grid Background="{StaticResource MainColor}">
+    <Grid Background="{StaticResource MainColor}" Focusable="True">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="200"/>
             <ColumnDefinition Width="147*"/>
@@ -31,7 +31,10 @@
             <RowDefinition Height="35" />
             <RowDefinition />
         </Grid.RowDefinitions>
-
+        <i:Interaction.Behaviors>
+            <behaviours:ClearFocusOnClickBehavior/>
+        </i:Interaction.Behaviors>
+        
         <DockPanel Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Background="{StaticResource MainColor}">
             <Label Foreground="White" FontSize="16">Settings</Label>
             <Button DockPanel.Dock="Right" HorizontalAlignment="Right" Style="{StaticResource CloseButtonStyle}"

--- a/PixiEditor/Views/MainWindow.xaml
+++ b/PixiEditor/Views/MainWindow.xaml
@@ -10,7 +10,7 @@
         xmlns:ui="clr-namespace:PixiEditor.Helpers.UI"
         xmlns:cmd="http://www.galasoft.ch/mvvmlight" 
         xmlns:avalondock="https://github.com/Dirkster99/AvalonDock"
-        xmlns:colorpicker="clr-namespace:ColorPicker;assembly=ColorPicker" xmlns:usercontrols="clr-namespace:PixiEditor.Views.UserControls"
+        xmlns:colorpicker="clr-namespace:ColorPicker;assembly=ColorPicker" xmlns:usercontrols="clr-namespace:PixiEditor.Views.UserControls" xmlns:behaviours="clr-namespace:PixiEditor.Helpers.Behaviours"
         mc:Ignorable="d" WindowStyle="None" Initialized="MainWindow_Initialized"
         Title="PixiEditor" Name="mainWindow" Height="1000" Width="1600" Background="{StaticResource MainColor}"
         WindowStartupLocation="CenterScreen" WindowState="Maximized" DataContext="{DynamicResource ViewModelMain}">
@@ -57,7 +57,7 @@
             <cmd:EventToCommand Command="{Binding CloseWindowCommand}" PassEventArgsToCommand="True" />
         </i:EventTrigger>
     </i:Interaction.Triggers>
-    <Grid Name="mainGrid" Margin="5">
+    <Grid Name="mainGrid" Margin="5" Focusable="True">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="45" />
             <ColumnDefinition Width="1*" />
@@ -69,7 +69,9 @@
             <RowDefinition Height="1*" />
             <RowDefinition Height="30" />
         </Grid.RowDefinitions>
-
+        <i:Interaction.Behaviors>
+            <behaviours:ClearFocusOnClickBehavior/>
+        </i:Interaction.Behaviors>
         <DockPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Background="{StaticResource MainColor}">
             <Image DockPanel.Dock="Left" HorizontalAlignment="Left" VerticalAlignment="Top"
                    Source="/Images/PixiEditorLogo.png" Width="20" Height="20" Margin="5,5,0,0" />

--- a/PixiEditor/Views/UserControls/NumberInput.xaml
+++ b/PixiEditor/Views/UserControls/NumberInput.xaml
@@ -16,6 +16,5 @@
                 <behaviours:TextBoxFocusBehavior />
             </i:Interaction.Behaviors>
         </TextBox>
-        <TextBox Width="0" Height="0" />
     </Grid>
 </UserControl>

--- a/PixiEditor/Views/UserControls/NumberInput.xaml.cs
+++ b/PixiEditor/Views/UserControls/NumberInput.xaml.cs
@@ -7,7 +7,7 @@ using System.Windows.Input;
 namespace PixiEditor.Views
 {
     /// <summary>
-    ///     Interaction logic for NumerInput.xaml
+    ///     Interaction logic for NumerInput.xaml.
     /// </summary>
     public partial class NumberInput : UserControl
     {
@@ -34,20 +34,20 @@ namespace PixiEditor.Views
 
         public float Value
         {
-            get => (float) GetValue(ValueProperty);
+            get => (float)GetValue(ValueProperty);
             set => SetValue(ValueProperty, value);
         }
 
         public float Min
         {
-            get => (float) GetValue(MinProperty);
+            get => (float)GetValue(MinProperty);
             set => SetValue(MinProperty, value);
         }
 
 
         public float Max
         {
-            get => (float) GetValue(MaxProperty);
+            get => (float)GetValue(MaxProperty);
             set => SetValue(MaxProperty, value);
         }
 


### PR DESCRIPTION
Fixes #108

Removed zero-width textbox, which was a hacky fix to remove the focus. Not Ctrl does not get blocked. 