### PR TITLE
Small improvements

### DIFF
--- a/PixiEditor/Helpers/Converters/NotNullToBoolConverter.cs
+++ b/PixiEditor/Helpers/Converters/NotNullToBoolConverter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace PixiEditor.Helpers.Converters
+{
+    [ValueConversion(typeof(object), typeof(bool))]
+    public class NotNullToBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            bool result = value != null;
+            if (parameter != null)
+            {
+                return !result;
+            }
+
+            return result;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value;
+        }
+    }
+}

--- a/PixiEditor/Models/Layers/Layer.cs
+++ b/PixiEditor/Models/Layers/Layer.cs
@@ -64,7 +64,7 @@ namespace PixiEditor.Models.Layers
             set
             {
                 name = value;
-                RaisePropertyChanged("Name");
+                RaisePropertyChanged(nameof(Name));
             }
         }
 
@@ -74,7 +74,7 @@ namespace PixiEditor.Models.Layers
             set
             {
                 isActive = value;
-                RaisePropertyChanged("IsActive");
+                RaisePropertyChanged(nameof(IsActive));
             }
         }
 
@@ -85,6 +85,20 @@ namespace PixiEditor.Models.Layers
             {
                 if (isVisible != value)
                 {
+                    isVisible = value;
+                    RaisePropertyChanged(nameof(IsVisible));
+                    RaisePropertyChanged(nameof(IsVisibleUndoTriggerable));
+                }
+            }
+        }
+
+        public bool IsVisibleUndoTriggerable
+        {
+            get => IsVisible;
+            set
+            {
+                if (value != IsVisible)
+                {
                     ViewModelMain.Current?.BitmapManager?.ActiveDocument?.UndoManager
                         .AddUndoChange(
                         new Change(
@@ -93,9 +107,8 @@ namespace PixiEditor.Models.Layers
                             value,
                             LayerHelper.FindLayerByGuidProcess,
                             new object[] { LayerGuid },
-                            "Change layer visibility"), true);
-                    isVisible = value;
-                    RaisePropertyChanged("IsVisible");
+                            "Change layer visibility"));
+                    IsVisible = value;
                 }
             }
         }
@@ -116,7 +129,7 @@ namespace PixiEditor.Models.Layers
             set
             {
                 layerBitmap = value;
-                RaisePropertyChanged("LayerBitmap");
+                RaisePropertyChanged(nameof(LayerBitmap));
             }
         }
 
@@ -127,17 +140,30 @@ namespace PixiEditor.Models.Layers
             {
                 if (opacity != value)
                 {
-                    ViewModelMain.Current?.BitmapManager?.ActiveDocument?.UndoManager
-                        .AddUndoChange(
-                            new Change(
-                            nameof(Opacity),
-                            opacity,
-                            value,
-                            LayerHelper.FindLayerByGuidProcess,
-                            new object[] { LayerGuid },
-                            "Change layer opacity"), true);
                     opacity = value;
-                    RaisePropertyChanged("Opacity");
+                    RaisePropertyChanged(nameof(Opacity));
+                    RaisePropertyChanged(nameof(OpacityUndoTriggerable));
+                }
+            }
+        }
+
+        public float OpacityUndoTriggerable
+        {
+            get => Opacity;
+            set
+            {
+                if (value != Opacity)
+                {
+                    ViewModelMain.Current?.BitmapManager?.ActiveDocument?.UndoManager
+                    .AddUndoChange(
+                                   new Change(
+                                   nameof(Opacity),
+                                   opacity,
+                                   value,
+                                   LayerHelper.FindLayerByGuidProcess,
+                                   new object[] { LayerGuid },
+                                   "Change layer opacity"));
+                    Opacity = value;
                 }
             }
         }

--- a/PixiEditor/Models/Tools/Tools/ColorPickerTool.cs
+++ b/PixiEditor/Models/Tools/Tools/ColorPickerTool.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using System.Windows.Input;
 using PixiEditor.Models.Position;
 using PixiEditor.ViewModels;
 using Color = System.Windows.Media.Color;
@@ -14,10 +15,13 @@ namespace PixiEditor.Models.Tools.Tools
             Tooltip = "Swaps primary color with selected on canvas. (O)";
         }
 
-        public override void Use(Coordinates[] coordinates)
+        public override void OnMouseDown(MouseEventArgs e)
         {
+            base.OnMouseDown(e);
             ViewModelMain.Current.ColorsSubViewModel.PrimaryColor = GetColorUnderMouse();
         }
+
+        public override void Use(Coordinates[] coordinates) { }
 
         public Color GetColorUnderMouse()
         {

--- a/PixiEditor/Models/Tools/Tools/ColorPickerTool.cs
+++ b/PixiEditor/Models/Tools/Tools/ColorPickerTool.cs
@@ -21,7 +21,10 @@ namespace PixiEditor.Models.Tools.Tools
             ViewModelMain.Current.ColorsSubViewModel.PrimaryColor = GetColorUnderMouse();
         }
 
-        public override void Use(Coordinates[] coordinates) { }
+        public override void Use(Coordinates[] coordinates)
+        {
+            ViewModelMain.Current.ColorsSubViewModel.PrimaryColor = GetColorUnderMouse();
+        }
 
         public Color GetColorUnderMouse()
         {

--- a/PixiEditor/Models/Tools/Tools/PenTool.cs
+++ b/PixiEditor/Models/Tools/Tools/PenTool.cs
@@ -22,7 +22,7 @@ namespace PixiEditor.Models.Tools.Tools
         private readonly BoolSetting pixelPerfectSetting;
         private readonly LineTool lineTool;
         private Coordinates[] lastChangedPixels = new Coordinates[3];
-        private List<Coordinates> confirmedPixels = new List<Coordinates>();
+        private readonly List<Coordinates> confirmedPixels = new List<Coordinates>();
         private byte changedPixelsindex = 0;
 
         public PenTool()
@@ -50,10 +50,10 @@ namespace PixiEditor.Models.Tools.Tools
         {
             Coordinates startingCords = coordinates.Length > 1 ? coordinates[1] : coordinates[0];
             BitmapPixelChanges pixels = Draw(
-                startingCords, 
-                coordinates[0], 
-                color, 
-                toolSizeSetting.Value, 
+                startingCords,
+                coordinates[0],
+                color,
+                toolSizeSetting.Value,
                 pixelPerfectSetting.Value,
                 ViewModelMain.Current.BitmapManager.ActiveDocument.PreviewLayer);
             return Only(pixels, layer);

--- a/PixiEditor/Properties/AssemblyInfo.cs
+++ b/PixiEditor/Properties/AssemblyInfo.cs
@@ -50,5 +50,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.4.1")]
-[assembly: AssemblyFileVersion("0.1.4.1")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]

--- a/PixiEditor/Views/MainWindow.xaml
+++ b/PixiEditor/Views/MainWindow.xaml
@@ -25,6 +25,7 @@
             <vm:ViewModelMain x:Key="ViewModelMain" />
             <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
             <converters:BoolToIntConverter x:Key="BoolToIntConverter" />
+            <converters:NotNullToBoolConverter x:Key="NotNullToBoolConverter" />
             <converters:FloatNormalizeConverter x:Key="FloatNormalizeConverter" />
             <converters:DoubleToIntConverter x:Key="DoubleToIntConverter"/>
             <ResourceDictionary.MergedDictionaries>
@@ -294,8 +295,13 @@
                                             Style="{StaticResource DarkRoundButton}" />
                                             <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="10,0">
                                                 <Label Content="Opacity" Foreground="White" VerticalAlignment="Center"/>
-                                                <vws:NumberInput Min="0" Max="100" Width="40" Height="20" VerticalAlignment="Center"
-                                                         Value="{Binding BitmapManager.ActiveDocument.ActiveLayer.Opacity, Mode=TwoWay, 
+                                                <vws:NumberInput 
+                                                    Min="0" Max="100"
+                                                    IsEnabled="{Binding Path=BitmapManager.ActiveDocument, 
+                                                    Converter={StaticResource NotNullToBoolConverter}}" 
+                                                    Width="40" Height="20"
+                                                    VerticalAlignment="Center"
+                                                   Value="{Binding BitmapManager.ActiveDocument.ActiveLayer.OpacityUndoTriggerable, Mode=TwoWay, 
                                             Converter={StaticResource FloatNormalizeConverter}}" />
                                                 <Label Content="%" Foreground="White" VerticalAlignment="Center"/>
                                             </StackPanel>
@@ -381,14 +387,6 @@
             </ItemsControl>
         </StackPanel>
 
-        <!--<Grid Grid.Column="2" Background="{StaticResource AccentColor}" Grid.Row="2" Grid.RowSpan="1">
-            <avalondock:DockingManager Foreground="White" Background="{StaticResource AccentColor}" BorderThickness="0">
-
-                <avalondock:DockingManager.Theme>
-                    <avalonDockTheme:PixiEditorDockTheme />
-                </avalondock:DockingManager.Theme>
-            </avalondock:DockingManager>
-        </Grid>-->
         <Grid Grid.Row="3" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>

--- a/PixiEditor/Views/UserControls/EditableTextBlock.xaml
+++ b/PixiEditor/Views/UserControls/EditableTextBlock.xaml
@@ -11,14 +11,14 @@
     </UserControl.Resources>
     <Grid>
         <TextBlock Foreground="Snow" MouseLeftButtonDown="TextBlock_MouseDown"
-                   TextTrimming="CharacterEllipsis"
+                   TextTrimming="CharacterEllipsis" Name="textBlock"
                    Visibility="{Binding Path=TextBlockVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
                    Text="{Binding Path=Text, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" />
         <TextBox Style="{StaticResource DarkTextBoxStyle}"
-                 LostFocus="TextBox_LostFocus" 
+                 LostFocus="TextBox_LostFocus"
                  Text="{Binding Path=Text, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
-                 KeyDown="TextBox_KeyDown"                 
-                 LostKeyboardFocus="textBox_LostKeyboardFocus"
+                 KeyDown="TextBox_KeyDown"
+                 LostKeyboardFocus="TextBox_LostKeyboardFocus"
                  Visibility="{Binding Path=TextBlockVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}, 
             Converter={StaticResource OppositeVisibilityConverter}}"
                  Name="textBox">

--- a/PixiEditor/Views/UserControls/EditableTextBlock.xaml.cs
+++ b/PixiEditor/Views/UserControls/EditableTextBlock.xaml.cs
@@ -1,6 +1,8 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using PixiEditor.Models.Controllers;
 using PixiEditor.Models.Controllers.Shortcuts;
 
@@ -29,9 +31,11 @@ namespace PixiEditor.Views
 
         // Using a DependencyProperty as the backing store for EnableEditing.  This enables animation, styling, binding, etc...
         public static readonly DependencyProperty EnableEditingProperty =
-            DependencyProperty.Register("IsEditing", typeof(bool), typeof(EditableTextBlock),
+            DependencyProperty.Register(
+                "IsEditing",
+                typeof(bool),
+                typeof(EditableTextBlock),
                 new PropertyMetadata(OnIsEditingChanged));
-
 
         public EditableTextBlock()
         {
@@ -61,7 +65,13 @@ namespace PixiEditor.Views
             ShortcutController.BlockShortcutExecution = true;
             TextBlockVisibility = Visibility.Hidden;
             IsEditing = true;
-            textBox.Focus();
+            Dispatcher.BeginInvoke(
+                DispatcherPriority.Input,
+                new Action(delegate()
+                {
+                    textBox.Focus();         // Set Logical Focus
+                    Keyboard.Focus(textBox); // Set Keyboard Focus
+                }));
             textBox.SelectAll();
         }
 
@@ -102,7 +112,7 @@ namespace PixiEditor.Views
             DisableEditing();
         }
 
-        private void textBox_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        private void TextBox_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
             DisableEditing();
         }

--- a/PixiEditor/Views/UserControls/LayerItem.xaml
+++ b/PixiEditor/Views/UserControls/LayerItem.xaml
@@ -12,8 +12,11 @@
     <UserControl.Resources>
         <converters:BoolToColorConverter x:Key="BoolToColorConverter" />
     </UserControl.Resources>
-    <Border BorderThickness="0 0 0 0.5" BorderBrush="Gray" MinWidth="60"
+    <Border BorderThickness="0 0 0 0.5" BorderBrush="Gray" MinWidth="60" Focusable="True"
             Background="{Binding IsActive, Mode=TwoWay, Converter={StaticResource BoolToColorConverter}}">
+        <i:Interaction.Behaviors>
+            <behaviors:ClearFocusOnClickBehavior/>
+        </i:Interaction.Behaviors>
         <i:Interaction.Triggers>
             <i:EventTrigger EventName="MouseDown">
                 <i:InvokeCommandAction Command="{Binding ElementName=uc, 
@@ -21,15 +24,12 @@
                                        CommandParameter="{Binding Path=LayerIndex, ElementName=uc}"/>
             </i:EventTrigger>
         </i:Interaction.Triggers>
-        <Grid Focusable="True">
+        <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="30"/>
                 <ColumnDefinition Width="199*"/>
                 <ColumnDefinition Width="20"/>
             </Grid.ColumnDefinitions>
-            <i:Interaction.Behaviors>
-                <behaviors:ClearFocusOnClickBehavior/>
-            </i:Interaction.Behaviors>
             <CheckBox Style="{StaticResource ImageCheckBox}" VerticalAlignment="Center"
                       IsThreeState="False" HorizontalAlignment="Center" 
                       IsChecked="{Binding Path=IsVisibleUndoTriggerable, Mode=TwoWay}" Grid.Column="0" Height="16" />

--- a/PixiEditor/Views/UserControls/LayerItem.xaml
+++ b/PixiEditor/Views/UserControls/LayerItem.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:PixiEditor.Views"
              xmlns:converters="clr-namespace:PixiEditor.Helpers.Converters"
-             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity" xmlns:behaviors="clr-namespace:PixiEditor.Helpers.Behaviours"
              mc:Ignorable="d" Focusable="True"
              d:DesignHeight="60" d:DesignWidth="250" Name="uc"
              MouseLeave="LayerItem_OnMouseLeave" MouseEnter="LayerItem_OnMouseEnter">
@@ -21,15 +21,18 @@
                                        CommandParameter="{Binding Path=LayerIndex, ElementName=uc}"/>
             </i:EventTrigger>
         </i:Interaction.Triggers>
-        <Grid>
+        <Grid Focusable="True">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="30"/>
                 <ColumnDefinition Width="199*"/>
                 <ColumnDefinition Width="20"/>
             </Grid.ColumnDefinitions>
+            <i:Interaction.Behaviors>
+                <behaviors:ClearFocusOnClickBehavior/>
+            </i:Interaction.Behaviors>
             <CheckBox Style="{StaticResource ImageCheckBox}" VerticalAlignment="Center"
                       IsThreeState="False" HorizontalAlignment="Center" 
-                      IsChecked="{Binding Path=IsVisible, Mode=TwoWay}" Grid.Column="0" Height="16" />
+                      IsChecked="{Binding Path=IsVisibleUndoTriggerable, Mode=TwoWay}" Grid.Column="0" Height="16" />
             <StackPanel Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Left" Margin="5,0,0,0">
                 <Image Source="{Binding PreviewImage,ElementName=uc}" Stretch="Uniform" Width="50" Height="20" Margin="0,0,20,0"
                        RenderOptions.BitmapScalingMode="NearestNeighbor"/>

--- a/PixiEditor/Views/UserControls/LayerItem.xaml.cs
+++ b/PixiEditor/Views/UserControls/LayerItem.xaml.cs
@@ -107,7 +107,6 @@ namespace PixiEditor.Views
             set { SetValue(MoveToFrontCommandProperty, value); }
         }
 
-
         private void LayerItem_OnMouseEnter(object sender, MouseEventArgs e)
         {
             ControlButtonsVisible = Visibility.Visible;

--- a/PixiEditor/Views/UserControls/MainDrawingPanel.xaml
+++ b/PixiEditor/Views/UserControls/MainDrawingPanel.xaml
@@ -9,7 +9,7 @@
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              mc:Ignorable="d" PreviewMouseDown="mainDrawingPanel_MouseDown" PreviewMouseUp="mainDrawingPanel_PreviewMouseUp"
              d:DesignHeight="450" d:DesignWidth="800" x:Name="mainDrawingPanel" PreviewMouseWheel="Zoombox_MouseWheel">
-    <xctk:Zoombox PreviewMouseDown="Zoombox_PreviewMouseDown" Cursor="{Binding Cursor}" Name="Zoombox" KeepContentInBounds="True"
+    <xctk:Zoombox PreviewMouseDown="Zoombox_PreviewMouseDown" Cursor="{Binding Cursor}" Name="Zoombox" KeepContentInBounds="False"
                   Loaded="Zoombox_Loaded" IsAnimated="False" MouseDown="Zoombox_MouseDown"
                   CurrentViewChanged="Zoombox_CurrentViewChanged" DragModifiers="Blocked" ZoomModifiers="None">
         <i:Interaction.Triggers>

--- a/PixiEditor/Views/UserControls/MainDrawingPanel.xaml.cs
+++ b/PixiEditor/Views/UserControls/MainDrawingPanel.xaml.cs
@@ -185,7 +185,6 @@ namespace PixiEditor.Views
         private void Zoombox_CurrentViewChanged(object sender, ZoomboxViewChangedEventArgs e)
         {
             Zoombox.MinScale = 32 / ((FrameworkElement)Item).Width;
-            Zoombox.KeepContentInBounds = !(Zoombox.Scale > Zoombox.MinScale * 35.0);
         }
 
         private void Zoombox_PreviewMouseDown(object sender, MouseButtonEventArgs e)

--- a/PixiEditor/Views/UserControls/NumberInput.xaml
+++ b/PixiEditor/Views/UserControls/NumberInput.xaml
@@ -3,15 +3,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:local="clr-namespace:PixiEditor.Views"
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              xmlns:behaviours="clr-namespace:PixiEditor.Helpers.Behaviours"
-             xmlns:ui="clr-namespace:PixiEditor.Helpers.UI"
-             mc:Ignorable="d" Focusable="True"
+             mc:Ignorable="d"
              d:DesignHeight="20" d:DesignWidth="40" x:Name="numberInput">
     <TextBox TextAlignment="Center" Style="{StaticResource DarkTextBoxStyle}" Focusable="True"
                
-             PreviewTextInput="TextBox_PreviewTextInput" Text="{Binding ElementName=numberInput, Path=Value, UpdateSourceTrigger=PropertyChanged}">
+             PreviewTextInput="TextBox_PreviewTextInput" Text="{Binding ElementName=numberInput, Path=Value}">
         <i:Interaction.Behaviors>
             <behaviours:TextBoxFocusBehavior/>
             <behaviours:GlobalShortcutFocusBehavior/>

--- a/PixiEditor/Views/UserControls/ToolSettingColorPicker.xaml
+++ b/PixiEditor/Views/UserControls/ToolSettingColorPicker.xaml
@@ -9,7 +9,7 @@
              d:Background="{StaticResource AccentColor}">
     <Grid>
         <StackPanel Orientation="Horizontal">
-            <colorpicker:PortableColorPicker x:Name="ColorPicker" SelectedColor="{Binding SelectedColor, ElementName=uc}"/>
+            <colorpicker:PortableColorPicker x:Name="ColorPicker" SelectedColor="{Binding SelectedColor, ElementName=uc,Mode=TwoWay}"/>
             <Button Command="{Binding CopyMainColorCommand, ElementName=uc}" Style="{StaticResource DarkRoundButton}" FontSize="12" Width="100" Margin="5,0,0,0">Copy Main Color</Button>
         </StackPanel>
     </Grid>


### PR DESCRIPTION
- Fixed ToolSettingColorPicker
- Fixed double click rename layer
- Fixed color picker tool not picking on single click
- Fixed #126 
- Fixed multiple document crash
- Disabled opacity number input when not any document present
- Changed opacity changes on LostFocus instead of PropertyChanged
- Changed assembly version to 0.2.0.0