### PR TITLE
BitmapOperationsUtility :  Shift functionality should not apply to PenTool

### DIFF
--- a/PixiEditor/Models/Controllers/BitmapOperationsUtility.cs
+++ b/PixiEditor/Models/Controllers/BitmapOperationsUtility.cs
@@ -128,8 +128,8 @@ namespace PixiEditor.Models.Controllers
             int thickness = sizeSetting != null ? sizeSetting.Value : 1;
 
             bool shiftDown = Keyboard.IsKeyDown(Key.LeftShift);
-            var isShapeTool = tool is ShapeTool;
-            if (shiftDown && !isShapeTool)
+           
+            if (shiftDown && tool.UsesShift)
             {
                 bool mouseInLine = MouseCordsNotInLine(mouseMoveCords, thickness);
 

--- a/PixiEditor/Models/Controllers/BitmapOperationsUtility.cs
+++ b/PixiEditor/Models/Controllers/BitmapOperationsUtility.cs
@@ -128,8 +128,8 @@ namespace PixiEditor.Models.Controllers
             int thickness = sizeSetting != null ? sizeSetting.Value : 1;
 
             bool shiftDown = Keyboard.IsKeyDown(Key.LeftShift);
-
-            if (shiftDown)
+            var isShapeTool = tool is ShapeTool;
+            if (shiftDown && !isShapeTool)
             {
                 bool mouseInLine = MouseCordsNotInLine(mouseMoveCords, thickness);
 

--- a/PixiEditor/Models/Tools/BitmapOperationTool.cs
+++ b/PixiEditor/Models/Tools/BitmapOperationTool.cs
@@ -15,7 +15,7 @@ namespace PixiEditor.Models.Tools
         public bool ClearPreviewLayerOnEachIteration { get; set; } = true;
 
         public bool UseDefaultUndoMethod { get; set; } = true;
-        public virtual bool UsesShift { get => true; }
+        public virtual bool UsesShift => true;
 
         private readonly LayerChange[] onlyLayerArr = new LayerChange[] { new LayerChange(BitmapPixelChanges.Empty, Guid.Empty) };
 

--- a/PixiEditor/Models/Tools/BitmapOperationTool.cs
+++ b/PixiEditor/Models/Tools/BitmapOperationTool.cs
@@ -15,6 +15,7 @@ namespace PixiEditor.Models.Tools
         public bool ClearPreviewLayerOnEachIteration { get; set; } = true;
 
         public bool UseDefaultUndoMethod { get; set; } = true;
+        public virtual bool UsesShift { get => true; }
 
         private readonly LayerChange[] onlyLayerArr = new LayerChange[] { new LayerChange(BitmapPixelChanges.Empty, Guid.Empty) };
 

--- a/PixiEditor/Models/Tools/Tools/BrightnessTool.cs
+++ b/PixiEditor/Models/Tools/Tools/BrightnessTool.cs
@@ -26,7 +26,8 @@ namespace PixiEditor.Models.Tools.Tools
             Toolbar = new BrightnessToolToolbar(CorrectionFactor);
         }
 
-        public override string Tooltip => "Makes pixel brighter or darker pixel (U). Hold Ctrl to make pixel darker.";
+		public override bool UsesShift => false;
+		public override string Tooltip => "Makes pixel brighter or darker pixel (U). Hold Ctrl to make pixel darker.";
 
         public BrightnessMode Mode { get; set; } = BrightnessMode.Default;
 

--- a/PixiEditor/Models/Tools/Tools/EraserTool.cs
+++ b/PixiEditor/Models/Tools/Tools/EraserTool.cs
@@ -20,7 +20,8 @@ namespace PixiEditor.Models.Tools.Tools
             pen = new PenTool(bitmapManager);
         }
 
-        public override string Tooltip => "Erasers color from pixel. (E)";
+        public override bool UsesShift => false;
+		public override string Tooltip => "Erasers color from pixel. (E)";
 
         public override LayerChange[] Use(Layer layer, List<Coordinates> coordinates, Color color)
         {

--- a/PixiEditor/Models/Tools/Tools/PenTool.cs
+++ b/PixiEditor/Models/Tools/Tools/PenTool.cs
@@ -100,8 +100,8 @@ namespace PixiEditor.Models.Tools.Tools
 
             return result;
         }
-
-        private void MovePixelsToCheck(BitmapPixelChanges changes)
+		public override bool UsesShift => false;
+		private void MovePixelsToCheck(BitmapPixelChanges changes)
         {
             if (changes.ChangedPixels[lastChangedPixels[1]].A != 0)
             {


### PR DESCRIPTION
BitmapOperationsUtility did not take in to account if the tool used was PenTool.
This patch adds a check that makes it so the PenTool is excluded from the "shift" functionality 

This fixes #203 