### PR TITLE
Increase SizeInput's length. Fixes #258

### DIFF
--- a/PixiEditor/Helpers/Converters/ToolSizeToIntConverter.cs
+++ b/PixiEditor/Helpers/Converters/ToolSizeToIntConverter.cs
@@ -12,7 +12,7 @@ namespace PixiEditor.Helpers.Converters
     {
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return string.Format("{0} {1}", value, "px");
+            return $"{value} px";
         }
 
         public override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/PixiEditor/Views/UserControls/SizeInput.xaml
+++ b/PixiEditor/Views/UserControls/SizeInput.xaml
@@ -10,7 +10,7 @@
              mc:Ignorable="d"
              d:DesignHeight="30" d:DesignWidth="160" Name="uc" LayoutUpdated="UserControlLayoutUpdated">
     <TextBox IsEnabled="{Binding IsEnabled, ElementName=uc}" HorizontalContentAlignment="Center"
-             Style="{StaticResource DarkTextBoxStyle}" MaxLength="4" InputScope="Number">
+             Style="{StaticResource DarkTextBoxStyle}" InputScope="Number">
         <TextBox.Text>
             <Binding ElementName="uc"
                      Path="Size" Mode="TwoWay"


### PR DESCRIPTION
...And uses `$""` instead of `string.Format`.

 The title explains it all.
