### PR TITLE
#295 Restore a tool when Space is released

### DIFF
--- a/PixiEditor/ViewModels/SubViewModels/Main/ToolsViewModel.cs
+++ b/PixiEditor/ViewModels/SubViewModels/Main/ToolsViewModel.cs
@@ -176,7 +176,8 @@ namespace PixiEditor.ViewModels.SubViewModels.Main
         private void SetActiveTool(Type toolType)
         {
             Tool foundTool = ToolSet.First(x => x.GetType() == toolType);
-            SetActiveTool(foundTool);
+            if(ActiveTool != foundTool)//otherwise we would lost track of LastActionTool
+              SetActiveTool(foundTool);
         }
 
         private void SetToolCursor(Type tool)


### PR DESCRIPTION
#295 Restore a tool when Space is released

The change I made helps as long as you do not change an active tool. Once you do it  IoViewModel.ProcessShortcutDown is no longer called. Clearly some focus-related issue. Interestingly enough if you focus a layer at right side that problem with focus is not happening. So it looks like  a bigger issue of DrawingViewPort being defocused depend on user action. Seems like refocusing it back at the end of tool changing event handler would do the job but I do not know WPF well enough to do it. 
