### PR TITLE
Fixes

### DIFF
--- a/PixiEditor/Models/Controllers/ClipboardController.cs
+++ b/PixiEditor/Models/Controllers/ClipboardController.cs
@@ -138,7 +138,6 @@ namespace PixiEditor.Models.Controllers
         /// <summary>
         ///     Gets image from clipboard, supported PNG, Dib and Bitmap.
         /// </summary>
-        /// <returns>WriteableBitmap.</returns>
         private static IEnumerable<Layer> GetLayersFromClipboard()
         {
             DataObject data = ClipboardHelper.TryGetDataObject();

--- a/PixiEditor/Models/Controllers/ClipboardController.cs
+++ b/PixiEditor/Models/Controllers/ClipboardController.cs
@@ -290,7 +290,7 @@ namespace PixiEditor.Models.Controllers
                     FormatConvertedBitmap newFormat = new FormatConvertedBitmap();
                     newFormat.BeginInit();
                     newFormat.Source = source;
-                    newFormat.DestinationFormat = PixelFormats.Rgba64;
+                    newFormat.DestinationFormat = PixelFormats.Bgra32;
                     newFormat.EndInit();
 
                     result = new Surface(newFormat);
@@ -315,7 +315,7 @@ namespace PixiEditor.Models.Controllers
 
             while (i < document.Layers.Count)
             {
-                document.RemoveLayer(i, true);
+                document.RemoveLayer(i, false);
             }
         }
 

--- a/PixiEditor/Models/DataHolders/Surface.cs
+++ b/PixiEditor/Models/DataHolders/Surface.cs
@@ -64,8 +64,9 @@ namespace PixiEditor.Models.DataHolders
             if (original.PixelWidth <= 0 || original.PixelHeight <= 0)
                 throw new ArgumentException("Surface dimensions must be non-zero");
 
-            byte[] pixels = new byte[original.PixelWidth * original.PixelHeight * 4];
-            original.CopyPixels(pixels, original.PixelWidth * 4, 0);
+            int stride = (original.PixelWidth * original.Format.BitsPerPixel + 7) / 8;
+            byte[] pixels = new byte[stride * original.PixelHeight];
+            original.CopyPixels(pixels, stride, 0);
 
             Width = original.PixelWidth;
             Height = original.PixelHeight;

--- a/PixiEditor/Models/Undo/StorageBasedChange.cs
+++ b/PixiEditor/Models/Undo/StorageBasedChange.cs
@@ -348,6 +348,10 @@ namespace PixiEditor.Models.Undo
             int offsetDiffX = layerData.OffsetX - layer.OffsetX;
             int offsetDiffY = layerData.OffsetY - layer.OffsetY;
 
+            // Experiment with this, there is a bug, but I still don't know where. Code below might help
+            //if (widthBigger) offsetDiffX += chunk.Width - layer.Width;
+            //if (heightBigger) offsetDiffY += chunk.Height - layer.Height;
+
             bool offsetXBigger = Math.Abs(offsetDiffX) > 0;
             bool offsetYBigger = Math.Abs(offsetDiffY) > 0;
 

--- a/PixiEditor/Models/Undo/StorageBasedChange.cs
+++ b/PixiEditor/Models/Undo/StorageBasedChange.cs
@@ -348,9 +348,6 @@ namespace PixiEditor.Models.Undo
             int offsetDiffX = layerData.OffsetX - layer.OffsetX;
             int offsetDiffY = layerData.OffsetY - layer.OffsetY;
 
-            if (widthBigger) offsetDiffX += chunk.Width - layer.Width;
-            if (heightBigger) offsetDiffY += chunk.Height - layer.Height;
-
             bool offsetXBigger = Math.Abs(offsetDiffX) > 0;
             bool offsetYBigger = Math.Abs(offsetDiffY) > 0;
 

--- a/PixiEditor/Models/Undo/StorageBasedChange.cs
+++ b/PixiEditor/Models/Undo/StorageBasedChange.cs
@@ -348,6 +348,9 @@ namespace PixiEditor.Models.Undo
             int offsetDiffX = layerData.OffsetX - layer.OffsetX;
             int offsetDiffY = layerData.OffsetY - layer.OffsetY;
 
+            if (widthBigger) offsetDiffX += chunk.Width - layer.Width;
+            if (heightBigger) offsetDiffY += chunk.Height - layer.Height;
+
             bool offsetXBigger = Math.Abs(offsetDiffX) > 0;
             bool offsetYBigger = Math.Abs(offsetDiffY) > 0;
 

--- a/PixiEditor/PixiEditor.csproj
+++ b/PixiEditor/PixiEditor.csproj
@@ -182,7 +182,7 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Dirkster.AvalonDock" Version="4.60.0" />
+		<PackageReference Include="Dirkster.AvalonDock" Version="4.60.1" />
 		<PackageReference Include="DiscordRichPresence" Version="1.0.175" />
 		<PackageReference Include="Expression.Blend.Sdk">
 			<Version>1.0.2</Version>
@@ -196,7 +196,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="PixiEditor.ColorPicker" Version="3.1.0" />
 		<PackageReference Include="PixiEditor.Parser" Version="2.0.0" />
-		<PackageReference Include="PixiEditor.Parser.Skia" Version="2.0.0" />
+		<PackageReference Include="PixiEditor.Parser.Skia" Version="2.0.0.1" />
 		<PackageReference Include="SkiaSharp" Version="2.80.3" />
 		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
 		<PackageReference Include="WriteableBitmapEx">

--- a/PixiEditor/Properties/AssemblyInfo.cs
+++ b/PixiEditor/Properties/AssemblyInfo.cs
@@ -50,5 +50,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.7.0")]
-[assembly: AssemblyFileVersion("0.1.7.0")]
+[assembly: AssemblyVersion("0.1.8.0")]
+[assembly: AssemblyFileVersion("0.1.8.0")]

--- a/PixiEditor/Styles/ThemeStyle.xaml
+++ b/PixiEditor/Styles/ThemeStyle.xaml
@@ -5,6 +5,10 @@
         <Setter Property="Foreground" Value="White" />
     </Style>
 
+    <Style TargetType="{x:Type Grid}">
+        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+    </Style>
+
     <Style TargetType="Button" x:Key="BaseDarkButton">
         <Setter Property="Background" Value="#404040" />
         <Setter Property="Foreground" Value="White" />


### PR DESCRIPTION
- Updated PixiParser and AvalonDock
- Fixed how stride is caluclated, when converting pasted bitmaps
- Fixed paste infinite undo/redo adding loop
- Changed target format of unsupported PNG color formats to Bgra32 instead of Rgba64 (Skia had problem with that for some reason)
- Removed focus outline for grids