### PR TITLE
#277 Add regular image formats to the save as dialog, open dialog extensions

### DIFF
--- a/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
+++ b/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
@@ -22,7 +22,7 @@ namespace PixiEditor.Helpers.Converters
             AssignFormat2Brush(FileType.Pixi, ColorBrush(226, 1, 45));
             AssignFormat2Brush(FileType.Png, ColorBrush(56, 108, 254));
             AssignFormat2Brush(FileType.Jpeg, ColorBrush(36, 179, 66));
-            AssignFormat2Brush(FileType.Bmp, ColorBrush(40, 170, 236));
+            AssignFormat2Brush(FileType.Bmp, ColorBrush(255, 140, 0));
             AssignFormat2Brush(FileType.Gif, ColorBrush(180, 0, 255));
         }
         static void AssignFormat2Brush(FileType format, SolidColorBrush brush)

--- a/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
+++ b/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
@@ -12,29 +12,29 @@ namespace PixiEditor.Helpers.Converters
     public class FileExtensionToColorConverter :
         SingleInstanceConverter<FileExtensionToColorConverter>
     {
-        private static readonly Dictionary<string, SolidColorBrush> extensions2Brushes;
+        private static readonly Dictionary<string, SolidColorBrush> extensionsToBrushes;
         public static readonly SolidColorBrush UnknownBrush = ColorBrush(100, 100, 100);
 
         static FileExtensionToColorConverter()
         {
-            extensions2Brushes = new Dictionary<string, SolidColorBrush>();
-            AssignFormat2Brush(FileType.Unset, UnknownBrush);
-            AssignFormat2Brush(FileType.Pixi, ColorBrush(226, 1, 45));
-            AssignFormat2Brush(FileType.Png, ColorBrush(56, 108, 254));
-            AssignFormat2Brush(FileType.Jpeg, ColorBrush(36, 179, 66));
-            AssignFormat2Brush(FileType.Bmp, ColorBrush(255, 140, 0));
-            AssignFormat2Brush(FileType.Gif, ColorBrush(180, 0, 255));
+            extensionsToBrushes = new Dictionary<string, SolidColorBrush>();
+            AssignFormatToBrush(FileType.Unset, UnknownBrush);
+            AssignFormatToBrush(FileType.Pixi, ColorBrush(226, 1, 45));
+            AssignFormatToBrush(FileType.Png, ColorBrush(56, 108, 254));
+            AssignFormatToBrush(FileType.Jpeg, ColorBrush(36, 179, 66));
+            AssignFormatToBrush(FileType.Bmp, ColorBrush(255, 140, 0));
+            AssignFormatToBrush(FileType.Gif, ColorBrush(180, 0, 255));
         }
-        static void AssignFormat2Brush(FileType format, SolidColorBrush brush)
+        static void AssignFormatToBrush(FileType format, SolidColorBrush brush)
         {
-            SupportedFilesHelper.GetFileTypeDialogData(format).Extensions.ForEach(i => extensions2Brushes[i] = brush);
+            SupportedFilesHelper.GetFileTypeDialogData(format).Extensions.ForEach(i => extensionsToBrushes[i] = brush);
         }
         
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             string extension = (string)value;
 
-            return extensions2Brushes.ContainsKey(extension) ? extensions2Brushes[extension] : UnknownBrush;
+            return extensionsToBrushes.ContainsKey(extension) ? extensionsToBrushes[extension] : UnknownBrush;
         }
 
         private static SolidColorBrush ColorBrush(byte r, byte g, byte b)

--- a/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
+++ b/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.Windows.Media;
+using PixiEditor.Models.Enums;
 
 namespace PixiEditor.Helpers.Converters
 {
@@ -12,35 +13,28 @@ namespace PixiEditor.Helpers.Converters
         SingleInstanceConverter<FileExtensionToColorConverter>
     {
         private static readonly Dictionary<string, SolidColorBrush> extensions2Brushes;
-
         public static readonly SolidColorBrush UnknownBrush = ColorBrush(100, 100, 100);
 
         static FileExtensionToColorConverter()
         {
             extensions2Brushes = new Dictionary<string, SolidColorBrush>();
-            AssignFormat2Brush(Constants.NativeExtension, ColorBrush(226, 1, 45));
-            AssignFormat2Brush(ImageFormat.Png, ColorBrush(56, 108, 254));
-            AssignFormat2Brush(ImageFormat.Jpeg, ColorBrush(36, 179, 66));
-            AssignFormat2Brush(ImageFormat.Bmp, ColorBrush(40, 170, 236));
-            AssignFormat2Brush(ImageFormat.Gif, ColorBrush(180, 0, 255));
+            AssignFormat2Brush(FileType.Unset, UnknownBrush);
+            AssignFormat2Brush(FileType.Pixi, ColorBrush(226, 1, 45));
+            AssignFormat2Brush(FileType.Png, ColorBrush(56, 108, 254));
+            AssignFormat2Brush(FileType.Jpeg, ColorBrush(36, 179, 66));
+            AssignFormat2Brush(FileType.Bmp, ColorBrush(40, 170, 236));
+            AssignFormat2Brush(FileType.Gif, ColorBrush(180, 0, 255));
         }
-        static void AssignFormat2Brush(ImageFormat format, SolidColorBrush brush)
+        static void AssignFormat2Brush(FileType format, SolidColorBrush brush)
         {
-            SupportedFilesHelper.GetFormatExtensions(format).ForEach(i => AssignFormat2Brush(i, brush));
+            SupportedFilesHelper.GetFileTypeDialogData(format).Extensions.ForEach(i => extensions2Brushes[i] = brush);
         }
-        static void AssignFormat2Brush(string format, SolidColorBrush brush)
-        {
-            extensions2Brushes[format] = brush;
-        }
-
+        
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             string extension = (string)value;
 
-            if (extensions2Brushes.ContainsKey(extension))
-                return extensions2Brushes[extension];
-
-            return UnknownBrush;
+            return extensions2Brushes.ContainsKey(extension) ? extensions2Brushes[extension] : UnknownBrush;
         }
 
         private static SolidColorBrush ColorBrush(byte r, byte g, byte b)

--- a/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
+++ b/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using PixiEditor.Models;
+using System;
+using System.Collections.Generic;
+using System.Drawing.Imaging;
 using System.Globalization;
 using System.Windows.Media;
 
@@ -7,30 +10,26 @@ namespace PixiEditor.Helpers.Converters
     public class FileExtensionToColorConverter :
         SingleInstanceConverter<FileExtensionToColorConverter>
     {
-        private static readonly SolidColorBrush PixiBrush = ColorBrush(226, 1, 45);
-
-        private static readonly SolidColorBrush PngBrush = ColorBrush(56, 108, 254);
-
-        private static readonly SolidColorBrush JpgBrush = ColorBrush(36, 179, 66);
+        private static readonly Dictionary<string, SolidColorBrush> extensions2Brushes;
 
         private static readonly SolidColorBrush UnknownBrush = ColorBrush(100, 100, 100);
+
+        static FileExtensionToColorConverter()
+        {
+            extensions2Brushes = new Dictionary<string, SolidColorBrush>();
+            extensions2Brushes[Constants.NativeExtension] = ColorBrush(226, 1, 45);
+            extensions2Brushes[SupportedFilesHelper.Format2Extension(ImageFormat.Png)] = ColorBrush(56, 108, 254);
+            extensions2Brushes[SupportedFilesHelper.Format2Extension(ImageFormat.Jpeg)] = ColorBrush(36, 179, 66);
+            extensions2Brushes[SupportedFilesHelper.Format2Extension(ImageFormat.Bmp)] = ColorBrush(40, 170, 236);
+            extensions2Brushes[SupportedFilesHelper.Format2Extension(ImageFormat.Gif)] = ColorBrush(180, 0, 255);
+        }
 
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             string extension = (string)value;
 
-            if (extension == ".pixi")
-            {
-                return PixiBrush;
-            }
-            else if (extension == ".png")
-            {
-                return PngBrush;
-            }
-            else if (extension is ".jpg" or ".jpeg")
-            {
-                return JpgBrush;
-            }
+            if (extensions2Brushes.ContainsKey(extension))
+                return extensions2Brushes[extension];
 
             return UnknownBrush;
         }

--- a/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
+++ b/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
@@ -13,7 +13,7 @@ namespace PixiEditor.Helpers.Converters
     {
         private static readonly Dictionary<string, SolidColorBrush> extensions2Brushes;
 
-        private static readonly SolidColorBrush UnknownBrush = ColorBrush(100, 100, 100);
+        public static readonly SolidColorBrush UnknownBrush = ColorBrush(100, 100, 100);
 
         static FileExtensionToColorConverter()
         {

--- a/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
+++ b/PixiEditor/Helpers/Converters/FileExtensionToColorConverter.cs
@@ -1,5 +1,6 @@
 ﻿using PixiEditor.Models;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Drawing.Imaging;
 using System.Globalization;
@@ -17,11 +18,19 @@ namespace PixiEditor.Helpers.Converters
         static FileExtensionToColorConverter()
         {
             extensions2Brushes = new Dictionary<string, SolidColorBrush>();
-            extensions2Brushes[Constants.NativeExtension] = ColorBrush(226, 1, 45);
-            extensions2Brushes[SupportedFilesHelper.Format2Extension(ImageFormat.Png)] = ColorBrush(56, 108, 254);
-            extensions2Brushes[SupportedFilesHelper.Format2Extension(ImageFormat.Jpeg)] = ColorBrush(36, 179, 66);
-            extensions2Brushes[SupportedFilesHelper.Format2Extension(ImageFormat.Bmp)] = ColorBrush(40, 170, 236);
-            extensions2Brushes[SupportedFilesHelper.Format2Extension(ImageFormat.Gif)] = ColorBrush(180, 0, 255);
+            AssignFormat2Brush(Constants.NativeExtension, ColorBrush(226, 1, 45));
+            AssignFormat2Brush(ImageFormat.Png, ColorBrush(56, 108, 254));
+            AssignFormat2Brush(ImageFormat.Jpeg, ColorBrush(36, 179, 66));
+            AssignFormat2Brush(ImageFormat.Bmp, ColorBrush(40, 170, 236));
+            AssignFormat2Brush(ImageFormat.Gif, ColorBrush(180, 0, 255));
+        }
+        static void AssignFormat2Brush(ImageFormat format, SolidColorBrush brush)
+        {
+            SupportedFilesHelper.GetFormatExtensions(format).ForEach(i => AssignFormat2Brush(i, brush));
+        }
+        static void AssignFormat2Brush(string format, SolidColorBrush brush)
+        {
+            extensions2Brushes[format] = brush;
         }
 
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/PixiEditor/Helpers/SupportedFilesHelper.cs
+++ b/PixiEditor/Helpers/SupportedFilesHelper.cs
@@ -5,7 +5,6 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 
-
 namespace PixiEditor.Helpers
 {
     internal class SupportedFilesHelper

--- a/PixiEditor/Helpers/SupportedFilesHelper.cs
+++ b/PixiEditor/Helpers/SupportedFilesHelper.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace PixiEditor.Helpers
 {
-    internal class SupportedFilesHelper
+    public class SupportedFilesHelper
     {
         static ImageFormat[] _imageFormats = new[] { ImageFormat.Png, ImageFormat.Jpeg, ImageFormat.Bmp, ImageFormat.Gif, /*ImageFormat.Tiff */};
         static Dictionary<string, List<string>> extensions;

--- a/PixiEditor/Helpers/SupportedFilesHelper.cs
+++ b/PixiEditor/Helpers/SupportedFilesHelper.cs
@@ -1,0 +1,80 @@
+﻿using PixiEditor.Models;
+using System;
+using System.Collections.Generic;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+
+
+namespace PixiEditor.Helpers
+{
+    internal class SupportedFilesHelper
+    {
+        static ImageFormat[] _imageFormats = new[] { ImageFormat.Png, ImageFormat.Jpeg, ImageFormat.Bmp, ImageFormat.Gif, /*ImageFormat.Tiff */};
+        static Dictionary<string, List<string>> extensions;
+        public static ImageFormat[] ImageFormats { get => _imageFormats; }
+
+        static SupportedFilesHelper()
+        {
+            extensions = new Dictionary<string, List<string>>();
+            extensions[Constants.NativeExtension] = new List<string>() { Constants.NativeExtension };
+            foreach(var format in _imageFormats)
+                extensions[Format2Extension(format)] = GetExtensions(format);
+        }
+
+        public static IEnumerable<string> GetSupportedExtensions()
+        {
+            return extensions.SelectMany(i => i.Value);
+        }
+
+        public static List<string> GetExtensions(ImageFormat format)
+        {
+            var res = new List<string>();
+            res.Add(Format2Extension(format));
+            if (format == ImageFormat.Jpeg)
+                res.Add(".jpg");
+            return res;
+        }
+
+        private static string Format2Extension(ImageFormat format)
+        {
+            return "." + format.ToString().ToLower();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="imageFormat">ImageFormat</param>
+        /// <returns>Extensions of the image e.g. *.jpg;*.jpeg</returns>
+        public static string GetExtensionsFormattedForDialog(ImageFormat imageFormat)
+        {
+            var parts = GetExtensions(imageFormat);
+            return GetExtensionsFormattedForDialog(parts);
+        }
+
+        public static string GetExtensionsFormattedForDialog(IEnumerable<string> parts)
+        {
+            return string.Join(";", parts.Select(i => "*" + i));
+        }
+
+        public static bool IsSupportedFile(string path)
+        {
+            var ext = Path.GetExtension(path.ToLower());
+            return GetSupportedExtensions().Contains(ext);
+        }
+
+        public static bool IsExtensionSupported(string fileExtension)
+        {
+            return GetSupportedExtensions().Contains(fileExtension);
+        }
+
+        public static string GetFormattedFilesExtensions(bool includePixi)
+        {
+            var allExts = SupportedFilesHelper.GetSupportedExtensions().ToList();
+            if (!includePixi)
+                allExts.Remove(Constants.NativeExtension);
+            var imageFilesExts = SupportedFilesHelper.GetExtensionsFormattedForDialog(allExts);
+            return imageFilesExts;
+        }
+    }
+}

--- a/PixiEditor/Models/DataHolders/RecentlyOpenedDocument.cs
+++ b/PixiEditor/Models/DataHolders/RecentlyOpenedDocument.cs
@@ -43,11 +43,8 @@ namespace PixiEditor.Models.DataHolders
                 {
                     return "? (Corrupt)";
                 }
-
                 string extension = Path.GetExtension(filePath).ToLower();
-                return extension is not (".pixi" or ".png" or ".jpg" or ".jpeg")
-                    ? $"? ({extension})"
-                    : extension;
+                return SupportedFilesHelper.IsExtensionSupported(extension) ? extension : $"? ({extension})";
             }
         }
 
@@ -93,7 +90,7 @@ namespace PixiEditor.Models.DataHolders
 
                 return surface.ToWriteableBitmap();
             }
-            else if (FileExtension is ".png" or ".jpg" or ".jpeg")
+            else if (SupportedFilesHelper.IsExtensionSupported(FileExtension))
             {
                 WriteableBitmap bitmap = null;
 
@@ -114,6 +111,9 @@ namespace PixiEditor.Models.DataHolders
                     MaxAllowedWidthInPixels = Constants.MaxPreviewWidth,
                     MaxAllowedHeightInPixels = Constants.MaxPreviewHeight,
                 };
+
+                if (bitmap == null)
+                    return null;
 
                 return imageFileMaxSizeChecker.IsFileUnderMaxSize(bitmap) ?
                     bitmap

--- a/PixiEditor/Models/Dialogs/ExportFileDialog.cs
+++ b/PixiEditor/Models/Dialogs/ExportFileDialog.cs
@@ -1,4 +1,5 @@
-﻿using PixiEditor.Views;
+﻿using PixiEditor.Models.Enums;
+using PixiEditor.Views;
 using System.Drawing.Imaging;
 using System.Windows;
 
@@ -6,7 +7,7 @@ namespace PixiEditor.Models.Dialogs
 {
     public class ExportFileDialog : CustomDialog
     {
-        ImageFormat _chosenFormat;
+        FileType _chosenFormat;
 
         private int fileHeight;
 
@@ -59,7 +60,7 @@ namespace PixiEditor.Models.Dialogs
             }
         }
 
-        public ImageFormat ChosenFormat
+        public FileType ChosenFormat
         {
             get => _chosenFormat;
             set

--- a/PixiEditor/Models/Enums/FileType.cs
+++ b/PixiEditor/Models/Enums/FileType.cs
@@ -2,6 +2,6 @@
 {
     public enum FileType
     {
-        Png = 0
+        Unset, Pixi, Png, Jpeg, Bmp, Gif
     }
 }

--- a/PixiEditor/Models/IO/Exporter.cs
+++ b/PixiEditor/Models/IO/Exporter.cs
@@ -54,7 +54,7 @@ namespace PixiEditor.Models.IO
             {
                 var chosenFormat = ParseImageFormat(Path.GetExtension(path));
                 var bitmap = document.Renderer.FinalBitmap;
-                SaveAs(encodersFactory[chosenFormat], path, bitmap.PixelWidth, bitmap.PixelHeight, bitmap);
+                SaveAs(encodersFactory[chosenFormat](), path, bitmap.PixelWidth, bitmap.PixelHeight, bitmap);
             }
             else
             {
@@ -69,14 +69,14 @@ namespace PixiEditor.Models.IO
             return SupportedFilesHelper.ParseImageFormat(extension);
         }
 
-        static Dictionary<FileType, BitmapEncoder> encodersFactory = new Dictionary<FileType, BitmapEncoder>();
+        static Dictionary<FileType, Func<BitmapEncoder>> encodersFactory = new Dictionary<FileType, Func<BitmapEncoder>>();
 
         static Exporter()
         {
-            encodersFactory[FileType.Png] = new PngBitmapEncoder();
-            encodersFactory[FileType.Jpeg] = new JpegBitmapEncoder();
-            encodersFactory[FileType.Bmp] = new BmpBitmapEncoder(); 
-            encodersFactory[FileType.Gif] = new GifBitmapEncoder();
+            encodersFactory[FileType.Png] = () => new PngBitmapEncoder();
+            encodersFactory[FileType.Jpeg] = () => new JpegBitmapEncoder();
+            encodersFactory[FileType.Bmp] = () => new BmpBitmapEncoder(); 
+            encodersFactory[FileType.Gif] = () => new GifBitmapEncoder();
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace PixiEditor.Models.IO
           if (info.ShowDialog())
           {
             if(encodersFactory.ContainsKey(info.ChosenFormat))
-              SaveAs(encodersFactory[info.ChosenFormat], info.FilePath, info.FileWidth, info.FileHeight, bitmap);
+              SaveAs(encodersFactory[info.ChosenFormat](), info.FilePath, info.FileWidth, info.FileHeight, bitmap);
           }
         }
         public static void SaveAsGZippedBytes(string path, Surface surface)

--- a/PixiEditor/Models/IO/Exporter.cs
+++ b/PixiEditor/Models/IO/Exporter.cs
@@ -3,6 +3,7 @@ using PixiEditor.Helpers;
 using PixiEditor.Helpers.Extensions;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Dialogs;
+using PixiEditor.Models.Enums;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -63,24 +64,19 @@ namespace PixiEditor.Models.IO
             return path;
         }
 
-        public static ImageFormat ParseImageFormat(string fileExtension)
+        public static FileType ParseImageFormat(string extension)
         {
-            fileExtension = fileExtension.Replace(".", "");
-            return (ImageFormat)typeof(ImageFormat)
-                    .GetProperty(fileExtension, BindingFlags.Public | BindingFlags.Static | BindingFlags.IgnoreCase)
-                    .GetValue(null);
+            return SupportedFilesHelper.ParseImageFormat(extension);
         }
 
-        //TODO remove static methods/members
-        static Dictionary<ImageFormat,BitmapEncoder> encodersFactory = new Dictionary<ImageFormat, BitmapEncoder>();
+        static Dictionary<FileType, BitmapEncoder> encodersFactory = new Dictionary<FileType, BitmapEncoder>();
 
         static Exporter()
         {
-            encodersFactory[ImageFormat.Png] = new PngBitmapEncoder();
-            encodersFactory[ImageFormat.Jpeg] = new JpegBitmapEncoder();
-            encodersFactory[ImageFormat.Bmp] = new BmpBitmapEncoder(); 
-            encodersFactory[ImageFormat.Gif] = new GifBitmapEncoder();
-            encodersFactory[ImageFormat.Tiff] = new TiffBitmapEncoder();
+            encodersFactory[FileType.Png] = new PngBitmapEncoder();
+            encodersFactory[FileType.Jpeg] = new JpegBitmapEncoder();
+            encodersFactory[FileType.Bmp] = new BmpBitmapEncoder(); 
+            encodersFactory[FileType.Gif] = new GifBitmapEncoder();
         }
 
         /// <summary>

--- a/PixiEditor/Models/IO/Exporter.cs
+++ b/PixiEditor/Models/IO/Exporter.cs
@@ -26,7 +26,6 @@ namespace PixiEditor.Models.IO
         /// <param name="path">Path where file was saved.</param>
         public static bool SaveAsEditableFileWithDialog(Document document, out string path)
         {
-            
             SaveFileDialog dialog = new SaveFileDialog
             {
                 Filter = BuildFilter(true),

--- a/PixiEditor/Models/IO/Exporter.cs
+++ b/PixiEditor/Models/IO/Exporter.cs
@@ -28,7 +28,7 @@ namespace PixiEditor.Models.IO
         {
             SaveFileDialog dialog = new SaveFileDialog
             {
-                Filter = BuildFilter(true),
+                Filter = SupportedFilesHelper.BuildSaveFilter(true),
                 FilterIndex = 0
             };
             if ((bool)dialog.ShowDialog())
@@ -39,31 +39,6 @@ namespace PixiEditor.Models.IO
 
             path = string.Empty;
             return false;
-        }
-
-        public static string BuildFilter(bool includePixi)
-        {
-          string filter = string.Empty;
-          if(includePixi)
-            filter += GetFormattedString("PixiEditor Files", Constants.NativeExtensionNoDot) + "|";
-          filter += string.Join("|", SupportedFilesHelper.ImageFormats.Select(i => GetFormattedString(i)));
-          return filter;
-        }
-
-        public static string GetFormattedString(ImageFormat imageFormat)
-        {
-            return GetFormattedString(imageFormat.ToString() + " Images", SupportedFilesHelper.GetExtensionsFormattedForDialog(imageFormat));
-        }
-
-        /// <summary>
-        /// Returns formatted line describing image
-        /// </summary>
-        /// <param name="imageFormatDisplayName">Human name like 'PNG Images' </param>
-        /// <param name="extensions">Extensions of the image e.g. (*.jpg;*.jpeg)</param>
-        /// <returns>Description of the image kind, e.g. PNG Images (*.png)</returns>
-        private static string GetFormattedString(string imageFormatDisplayName, string extensions)
-        {
-            return $"{imageFormatDisplayName}|{extensions}";
         }
 
         /// <summary>

--- a/PixiEditor/Models/IO/Exporter.cs
+++ b/PixiEditor/Models/IO/Exporter.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Win32;
+using PixiEditor.Helpers;
 using PixiEditor.Helpers.Extensions;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Dialogs;
@@ -18,8 +19,6 @@ namespace PixiEditor.Models.IO
 {
     public class Exporter
     {
-        static ImageFormat[] _formats = new[] { ImageFormat.Png, ImageFormat.Jpeg, ImageFormat.Bmp, ImageFormat.Gif, ImageFormat.Tiff };
-        
         /// <summary>
         ///     Saves document as .pixi file that contains all document data.
         /// </summary>
@@ -27,10 +26,10 @@ namespace PixiEditor.Models.IO
         /// <param name="path">Path where file was saved.</param>
         public static bool SaveAsEditableFileWithDialog(Document document, out string path)
         {
-            var pixi = GetFormattedString("PixiEditor File", Constants.NativeExtensionNoDot);
+            
             SaveFileDialog dialog = new SaveFileDialog
             {
-                Filter = pixi + "|" + BuildFilter(),
+                Filter = BuildFilter(true),
                 FilterIndex = 0
             };
             if ((bool)dialog.ShowDialog())
@@ -43,21 +42,29 @@ namespace PixiEditor.Models.IO
             return false;
         }
 
-        public static string BuildFilter()
+        public static string BuildFilter(bool includePixi)
         {
-          var filter = string.Join("|", Formats.Select(i => GetFormattedString(i)));
+          string filter = string.Empty;
+          if(includePixi)
+            filter += GetFormattedString("PixiEditor Files", Constants.NativeExtensionNoDot) + "|";
+          filter += string.Join("|", SupportedFilesHelper.ImageFormats.Select(i => GetFormattedString(i)));
           return filter;
         }
 
         public static string GetFormattedString(ImageFormat imageFormat)
         {
-            var formatLower = imageFormat.ToString().ToLower();
-            return GetFormattedString(imageFormat.ToString() + " Image", formatLower);
+            return GetFormattedString(imageFormat.ToString() + " Images", SupportedFilesHelper.GetExtensionsFormattedForDialog(imageFormat));
         }
 
-        private static string GetFormattedString(string imageFormat, string formatLower)
+        /// <summary>
+        /// Returns formatted line describing image
+        /// </summary>
+        /// <param name="imageFormatDisplayName">Human name like 'PNG Images' </param>
+        /// <param name="extensions">Extensions of the image e.g. (*.jpg;*.jpeg)</param>
+        /// <returns>Description of the image kind, e.g. PNG Images (*.png)</returns>
+        private static string GetFormattedString(string imageFormatDisplayName, string extensions)
         {
-            return $"{imageFormat}|*.{formatLower}";
+            return $"{imageFormatDisplayName}|{extensions}";
         }
 
         /// <summary>
@@ -90,11 +97,10 @@ namespace PixiEditor.Models.IO
                     .GetValue(null);
         }
 
-        //static Dictionary<ImageFormat, Action<ExportFileDialog, WriteableBitmap>> encoders = new Dictionary<ImageFormat, Action<ExportFileDialog, WriteableBitmap>>();
         //TODO remove static methods/members
         static Dictionary<ImageFormat, Func<BitmapEncoder>> encodersFactory = new Dictionary<ImageFormat, Func<BitmapEncoder>>();
 
-        public static ImageFormat[] Formats { get => _formats; }
+        
 
         static Exporter()
         {

--- a/PixiEditor/Models/IO/Exporter.cs
+++ b/PixiEditor/Models/IO/Exporter.cs
@@ -79,7 +79,7 @@ namespace PixiEditor.Models.IO
             {
                 var chosenFormat = ParseImageFormat(Path.GetExtension(path));
                 var bitmap = document.Renderer.FinalBitmap;
-                SaveAs(encodersFactory[chosenFormat](), path, bitmap.PixelWidth, bitmap.PixelHeight, bitmap);
+                SaveAs(encodersFactory[chosenFormat], path, bitmap.PixelWidth, bitmap.PixelHeight, bitmap);
             }
             else
             {
@@ -98,17 +98,15 @@ namespace PixiEditor.Models.IO
         }
 
         //TODO remove static methods/members
-        static Dictionary<ImageFormat, Func<BitmapEncoder>> encodersFactory = new Dictionary<ImageFormat, Func<BitmapEncoder>>();
-
-        
+        static Dictionary<ImageFormat,BitmapEncoder> encodersFactory = new Dictionary<ImageFormat, BitmapEncoder>();
 
         static Exporter()
         {
-            encodersFactory[ImageFormat.Png] = () => { return new PngBitmapEncoder(); };
-            encodersFactory[ImageFormat.Jpeg] = () => { return new JpegBitmapEncoder(); };
-            encodersFactory[ImageFormat.Bmp] = () => { return new BmpBitmapEncoder(); };
-            encodersFactory[ImageFormat.Gif] = () => { return new GifBitmapEncoder(); };
-            encodersFactory[ImageFormat.Tiff] = () => { return new TiffBitmapEncoder(); };
+            encodersFactory[ImageFormat.Png] = new PngBitmapEncoder();
+            encodersFactory[ImageFormat.Jpeg] = new JpegBitmapEncoder();
+            encodersFactory[ImageFormat.Bmp] = new BmpBitmapEncoder(); 
+            encodersFactory[ImageFormat.Gif] = new GifBitmapEncoder();
+            encodersFactory[ImageFormat.Tiff] = new TiffBitmapEncoder();
         }
 
         /// <summary>
@@ -124,7 +122,7 @@ namespace PixiEditor.Models.IO
           if (info.ShowDialog())
           {
             if(encodersFactory.ContainsKey(info.ChosenFormat))
-              SaveAs(encodersFactory[info.ChosenFormat](), info.FilePath, info.FileWidth, info.FileHeight, bitmap);
+              SaveAs(encodersFactory[info.ChosenFormat], info.FilePath, info.FileWidth, info.FileHeight, bitmap);
           }
         }
         public static void SaveAsGZippedBytes(string path, Surface surface)

--- a/PixiEditor/Models/IO/FileTypeDialogData.cs
+++ b/PixiEditor/Models/IO/FileTypeDialogData.cs
@@ -1,0 +1,55 @@
+﻿using PixiEditor.Models.Enums;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PixiEditor.Models.IO
+{
+    public class FileTypeDialogData
+    {
+        public FileType FileType { get; set; }
+
+        /// <summary>
+        /// Gets or sets file type extensions e.g. {jpg,jpeg}
+        /// </summary>
+        public List<string> Extensions { get; set; }
+
+        /// <summary>
+        /// Gets file type's main extensions e.g. jpeg
+        /// </summary>
+        public string PrimaryExtension { get => Extensions.FirstOrDefault(); }
+
+        /// <summary>
+        /// Gets or sets name displayed before extension e.g. JPEG Files
+        /// </summary>
+        public string DisplayName { get; set; }
+
+        public FileTypeDialogData(FileType fileType)
+        {
+            FileType = fileType;
+            Extensions = new List<string>();
+            Extensions.Add("." + FileType.ToString().ToLower());
+            if (FileType == FileType.Jpeg)
+                Extensions.Add(".jpg");
+
+            if (fileType == FileType.Pixi)
+                DisplayName = "PixiEditor Files";
+            else
+                DisplayName = FileType.ToString() + " Images";
+        }
+
+        public string SaveFilter
+        {
+            get { return DisplayName + "|" + GetExtensionFormattedForDialog(PrimaryExtension); }
+        }
+
+        public string ExtensionsFormattedForDialog
+        {
+            get { return string.Join(";", Extensions.Select(i => GetExtensionFormattedForDialog(i))); }
+        }
+
+        string GetExtensionFormattedForDialog(string extension)
+        {
+            return "*" + extension;
+        }
+    }
+}

--- a/PixiEditor/Models/IO/FileTypeDialogDataSet.cs
+++ b/PixiEditor/Models/IO/FileTypeDialogDataSet.cs
@@ -1,0 +1,52 @@
+﻿using PixiEditor.Helpers;
+using PixiEditor.Models.Enums;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PixiEditor.Models.IO
+{
+    public class FileTypeDialogDataSet
+    {
+        public enum SetKind { Any, Pixi, Images }
+        IEnumerable<FileTypeDialogData> fileTypes;
+        string displayName;
+
+        public FileTypeDialogDataSet(SetKind kind, IEnumerable<FileTypeDialogData> fileTypes = null)
+        {
+            if (fileTypes == null)
+                fileTypes = SupportedFilesHelper.GetAllSupportedFileTypes(true);
+            var allSupportedExtensions = fileTypes;
+            if (kind == SetKind.Any)
+            {
+                Init("Any", allSupportedExtensions);
+            }
+            else if (kind == SetKind.Pixi)
+            {
+                Init("PixiEditor Files", new[] { new FileTypeDialogData(FileType.Pixi) });
+            }
+            else if (kind == SetKind.Images)
+            {
+                Init("Image Files", allSupportedExtensions, FileType.Pixi);
+            }
+        }
+        public FileTypeDialogDataSet(string displayName, IEnumerable<FileTypeDialogData> fileTypes, FileType? fileTypeToSkip = null)
+        {
+            Init(displayName, fileTypes, fileTypeToSkip);
+        }
+
+        private void Init(string displayName, IEnumerable<FileTypeDialogData> fileTypes, FileType? fileTypeToSkip = null)
+        {
+            var copy = fileTypes.ToList();
+            if (fileTypeToSkip.HasValue)
+                copy.RemoveAll(i => i.FileType == fileTypeToSkip.Value);
+            this.fileTypes = copy;
+
+            this.displayName = displayName;
+        }
+
+        public string GetFormattedTypes()
+        {
+            return displayName + " |" + string.Join(";", this.fileTypes.Select(i => i.ExtensionsFormattedForDialog));
+        }
+    }
+}

--- a/PixiEditor/Models/IO/Importer.cs
+++ b/PixiEditor/Models/IO/Importer.cs
@@ -7,6 +7,7 @@ using SkiaSharp;
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Media.Imaging;
 
@@ -87,8 +88,7 @@ namespace PixiEditor.Models.IO
 
         public static bool IsSupportedFile(string path)
         {
-            path = path.ToLower();
-            return path.EndsWith(".pixi") || path.EndsWith(".png") || path.EndsWith(".jpg") || path.EndsWith(".jpeg");
+            return SupportedFilesHelper.IsSupportedFile(path);
         }
 
         public static Surface LoadFromGZippedBytes(string path)

--- a/PixiEditor/ViewModels/ImportFilePopupViewModel.cs
+++ b/PixiEditor/ViewModels/ImportFilePopupViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using PixiEditor.Exceptions;
 using PixiEditor.Helpers;
+using PixiEditor.Models.IO;
 using System;
 using System.IO;
 using System.Windows;
@@ -69,12 +70,12 @@ namespace PixiEditor.ViewModels
 
         private void CheckForPath(string path)
         {
-            if (File.Exists(path) && (path.EndsWith(".png") || path.EndsWith(".jpeg") || path.EndsWith(".jpg")))
+            if (SupportedFilesHelper.IsSupportedFile(path))
             {
                 try
                 {
                     filePath = path;
-                    BitmapImage bitmap = new BitmapImage(new Uri(path));
+                    var bitmap = new BitmapImage(new Uri(path));
                     ImportHeight = bitmap.PixelHeight;
                     ImportWidth = bitmap.PixelWidth;
                 }

--- a/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
+++ b/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
@@ -61,8 +61,8 @@ namespace PixiEditor.ViewModels
             {
                 Title = "Export path",
                 CheckPathExists = true,
-                DefaultExt = "." + Exporter.Formats.First().ToString().ToLower(),
-                Filter = Exporter.BuildFilter()
+                DefaultExt = "." + SupportedFilesHelper.ImageFormats.First().ToString().ToLower(),
+                Filter = Exporter.BuildFilter(false)
             };
             if (path.ShowDialog() == true)
             {

--- a/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
+++ b/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Win32;
 using PixiEditor.Helpers;
+using PixiEditor.Models.Enums;
 using PixiEditor.Models.IO;
 using System;
 using System.Drawing.Imaging;
@@ -13,7 +14,7 @@ namespace PixiEditor.ViewModels
     internal class SaveFilePopupViewModel : ViewModelBase
     {
         private string _filePath;
-        private ImageFormat _chosenFormat;
+        private FileType _chosenFormat;
 
         public SaveFilePopupViewModel()
         {
@@ -39,7 +40,7 @@ namespace PixiEditor.ViewModels
             }
         }
 
-        public ImageFormat ChosenFormat 
+        public FileType ChosenFormat 
         { 
             get => _chosenFormat;
             set
@@ -61,8 +62,8 @@ namespace PixiEditor.ViewModels
             {
                 Title = "Export path",
                 CheckPathExists = true,
-                DefaultExt = "." + SupportedFilesHelper.ImageFormats.First().ToString().ToLower(),
-                Filter = SupportedFilesHelper.BuildSaveFilter(false)
+                Filter = SupportedFilesHelper.BuildSaveFilter(false),
+                FilterIndex = 0
             };
             if (path.ShowDialog() == true)
             {

--- a/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
+++ b/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
@@ -62,7 +62,7 @@ namespace PixiEditor.ViewModels
                 Title = "Export path",
                 CheckPathExists = true,
                 DefaultExt = "." + SupportedFilesHelper.ImageFormats.First().ToString().ToLower(),
-                Filter = Exporter.BuildFilter(false)
+                Filter = SupportedFilesHelper.BuildSaveFilter(false)
             };
             if (path.ShowDialog() == true)
             {

--- a/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
+++ b/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
@@ -2,11 +2,7 @@
 using PixiEditor.Helpers;
 using PixiEditor.Models.Enums;
 using PixiEditor.Models.IO;
-using System;
-using System.Drawing.Imaging;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Windows;
 
 namespace PixiEditor.ViewModels

--- a/PixiEditor/ViewModels/SubViewModels/Main/FileViewModel.cs
+++ b/PixiEditor/ViewModels/SubViewModels/Main/FileViewModel.cs
@@ -204,10 +204,8 @@ namespace PixiEditor.ViewModels.SubViewModels.Main
                 
         private void Open(object property)
         {
-            var filter = 
-                "Any |" + SupportedFilesHelper.GetFormattedFilesExtensions(true) + "|" + 
-                "PixiEditor Files |" + SupportedFilesHelper.GetExtensionsFormattedForDialog(new[] { Constants.NativeExtension }) + "|" +
-                "Image Files |" + SupportedFilesHelper.GetFormattedFilesExtensions(false);
+            var filter = SupportedFilesHelper.BuildOpenFilter();
+
             OpenFileDialog dialog = new OpenFileDialog
             {
                 Filter = filter,

--- a/PixiEditor/ViewModels/SubViewModels/Main/FileViewModel.cs
+++ b/PixiEditor/ViewModels/SubViewModels/Main/FileViewModel.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using PixiEditor.Exceptions;
 using PixiEditor.Helpers;
+using PixiEditor.Models;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.Dialogs;
 using PixiEditor.Models.IO;
@@ -10,6 +11,7 @@ using PixiEditor.Parser;
 using PixiEditor.Views.Dialogs;
 using System;
 using System.Collections.Generic;
+using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Windows;
@@ -199,16 +201,17 @@ namespace PixiEditor.ViewModels.SubViewModels.Main
                 }
             }
         }
-
+                
         private void Open(object property)
         {
+            var filter = 
+                "Any |" + SupportedFilesHelper.GetFormattedFilesExtensions(true) + "|" + 
+                "PixiEditor Files |" + SupportedFilesHelper.GetExtensionsFormattedForDialog(new[] { Constants.NativeExtension }) + "|" +
+                "Image Files |" + SupportedFilesHelper.GetFormattedFilesExtensions(false);
             OpenFileDialog dialog = new OpenFileDialog
             {
-                Filter =
-                "Any|*.pixi;*.png;*.jpg;*.jpeg;|" +
-                "PixiEditor Files | *.pixi|" +
-                "Image Files|*.png;*.jpg;*.jpeg;",
-                DefaultExt = "pixi"
+                Filter = filter,
+                FilterIndex = 0
             };
 
             if ((bool)dialog.ShowDialog())

--- a/PixiEditor/Views/Dialogs/ExportFilePopup.xaml.cs
+++ b/PixiEditor/Views/Dialogs/ExportFilePopup.xaml.cs
@@ -1,4 +1,5 @@
-﻿using PixiEditor.ViewModels;
+﻿using PixiEditor.Models.Enums;
+using PixiEditor.ViewModels;
 using System.Drawing.Imaging;
 using System.Windows;
 using System.Windows.Input;
@@ -54,7 +55,7 @@ namespace PixiEditor.Views
             set => dataContext.FilePath = value;
         }
 
-        public ImageFormat SaveFormat 
+        public FileType SaveFormat 
         {
             get => dataContext.ChosenFormat;
             set => dataContext.ChosenFormat = value;

--- a/PixiEditor/Views/UserControls/Layers/ReferenceLayer.xaml.cs
+++ b/PixiEditor/Views/UserControls/Layers/ReferenceLayer.xaml.cs
@@ -1,21 +1,12 @@
 ﻿using Microsoft.Win32;
 using PixiEditor.Helpers;
+using PixiEditor.Models.Enums;
 using PixiEditor.Models.IO;
 using PixiEditor.Models.Layers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using static PixiEditor.Helpers.SupportedFilesHelper;
 
 namespace PixiEditor.Views.UserControls.Layers
 {
@@ -52,12 +43,12 @@ namespace PixiEditor.Views.UserControls.Layers
 
         private string OpenFilePicker()
         {
-
+            var imagesFilter = new FileTypeDialogDataSet(FileTypeDialogDataSet.SetKind.Images).GetFormattedTypes();
             OpenFileDialog dialog = new OpenFileDialog
             {
                 Title = "Reference layer path",
                 CheckPathExists = true,
-                Filter = "Image Files | " + SupportedFilesHelper.GetFormattedFilesExtensions(false)
+                Filter = imagesFilter
             };
 
             return (bool)dialog.ShowDialog() ? dialog.FileName : null;

--- a/PixiEditor/Views/UserControls/Layers/ReferenceLayer.xaml.cs
+++ b/PixiEditor/Views/UserControls/Layers/ReferenceLayer.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Win32;
+using PixiEditor.Helpers;
 using PixiEditor.Models.IO;
 using PixiEditor.Models.Layers;
 using System;
@@ -56,7 +57,7 @@ namespace PixiEditor.Views.UserControls.Layers
             {
                 Title = "Reference layer path",
                 CheckPathExists = true,
-                Filter = "Image Files|*.png;*.jpeg;*.jpg|PNG Files|*.png|JPG Files|*.jpeg;*.jpg"
+                Filter = "Image Files | " + SupportedFilesHelper.GetFormattedFilesExtensions(false)
             };
 
             return (bool)dialog.ShowDialog() ? dialog.FileName : null;

--- a/PixiEditorTests/HelpersTests/ConvertersTests/FileExtensionToColorConverterTests.cs
+++ b/PixiEditorTests/HelpersTests/ConvertersTests/FileExtensionToColorConverterTests.cs
@@ -20,7 +20,7 @@ namespace PixiEditorTests.HelpersTests.ConvertersTests
         [Fact]
         public void TestThatEachFormatHasColor()
         {
-            SupportedFilesHelper.GetAllSupportedExtensions().ToList().ForEach(i =>
+            SupportedFilesHelper.AllSupportedExtensions.ToList().ForEach(i =>
             {
                 var typed = GetTypedColor(i);
                 Assert.NotEqual(FileExtensionToColorConverter.UnknownBrush, typed);

--- a/PixiEditorTests/HelpersTests/ConvertersTests/FileExtensionToColorConverterTests.cs
+++ b/PixiEditorTests/HelpersTests/ConvertersTests/FileExtensionToColorConverterTests.cs
@@ -1,0 +1,38 @@
+﻿using PixiEditor.Helpers;
+using PixiEditor.Helpers.Converters;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Media;
+using Xunit;
+
+namespace PixiEditorTests.HelpersTests.ConvertersTests
+{
+    public class FileExtensionToColorConverterTests
+    {
+        private static SolidColorBrush GetTypedColor(string ext)
+        {
+            var converter = new FileExtensionToColorConverter();
+            object value = converter.Convert(ext, typeof(int), null, CultureInfo.CurrentCulture);
+            Assert.IsType<SolidColorBrush>(value);
+            return value as SolidColorBrush;
+        }
+
+        [Fact]
+        public void TestThatEachFormatHasColor()
+        {
+            SupportedFilesHelper.GetAllSupportedExtensions().ToList().ForEach(i =>
+            {
+                var typed = GetTypedColor(i);
+                Assert.NotEqual(FileExtensionToColorConverter.UnknownBrush, typed);
+            });
+        }
+               
+        [Fact]
+        public void TestThatUnsupportedFormatHasDefaultColor()
+        {
+            var converter = new FileExtensionToColorConverter();
+            var typed = GetTypedColor(".abc");
+            Assert.Equal(FileExtensionToColorConverter.UnknownBrush, typed);
+        }
+    }
+}

--- a/PixiEditorTests/HelpersTests/SupportedFilesHelperTests.cs
+++ b/PixiEditorTests/HelpersTests/SupportedFilesHelperTests.cs
@@ -1,0 +1,45 @@
+﻿using PixiEditor.Helpers;
+using Xunit;
+
+namespace PixiEditorTests.HelpersTests
+{
+    public class SupportedFilesHelperTests
+    {
+        [Fact]
+        public void TestAllExtensionsAreSupported()
+        {
+            var all = SupportedFilesHelper.GetAllSupportedExtensions();
+            Assert.Contains(all, i => i == ".pixi");
+            Assert.Contains(all, i => i == ".png");
+            Assert.Contains(all, i => i == ".jpg");
+            Assert.Contains(all, i => i == ".jpeg");
+            Assert.Contains(all, i => i == ".bmp");
+            Assert.Contains(all, i => i == ".gif");
+        }
+
+        [Fact]
+        public void TestBuildSaveFilter()
+        {
+            var filter = SupportedFilesHelper.BuildSaveFilter(true);
+            Assert.Equal("PixiEditor Files|*.pixi|Png Images|*.png|Jpeg Images|*.jpeg|Bmp Images|*.bmp|Gif Images|*.gif", filter);
+        }
+
+        [Fact]
+        public void TestBuildOpenFilter()
+        {
+            var filter = SupportedFilesHelper.BuildOpenFilter();
+            Assert.Equal("Any |*.pixi;*.png;*.jpeg;*.jpg;*.bmp;*.gif|PixiEditor Files |*.pixi|Image Files |*.png;*.jpeg;*.jpg;*.bmp;*.gif", filter);
+        }
+
+        [Fact]
+        public void TestIsSupportedFile()
+        {
+            Assert.True(SupportedFilesHelper.IsSupportedFile("foo.png"));
+            Assert.True(SupportedFilesHelper.IsSupportedFile("foo.bmp"));
+            Assert.True(SupportedFilesHelper.IsSupportedFile("foo.jpg"));
+            Assert.True(SupportedFilesHelper.IsSupportedFile("foo.jpeg"));
+
+            Assert.False(SupportedFilesHelper.IsSupportedFile("foo.abc"));
+        }
+    }
+}

--- a/PixiEditorTests/HelpersTests/SupportedFilesHelperTests.cs
+++ b/PixiEditorTests/HelpersTests/SupportedFilesHelperTests.cs
@@ -8,7 +8,7 @@ namespace PixiEditorTests.HelpersTests
         [Fact]
         public void TestAllExtensionsAreSupported()
         {
-            var all = SupportedFilesHelper.GetAllSupportedExtensions();
+            var all = SupportedFilesHelper.AllSupportedExtensions;
             Assert.Contains(all, i => i == ".pixi");
             Assert.Contains(all, i => i == ".png");
             Assert.Contains(all, i => i == ".jpg");

--- a/PixiEditorTests/ModelsTests/IO/ImporterTests.cs
+++ b/PixiEditorTests/ModelsTests/IO/ImporterTests.cs
@@ -26,6 +26,8 @@ namespace PixiEditorTests.ModelsTests.IO
         [InlineData("dub.jpeg")]
         [InlineData("-.JPEG")]
         [InlineData("dub.jpg")]
+        [InlineData("dub.gif")]
+        [InlineData("dub.bmp")]
         public void TestThatIsSupportedFile(string file)
         {
             Assert.True(Importer.IsSupportedFile(file));


### PR DESCRIPTION
Save/Save As dialogs have now same file types as export dialog.
Open dialog supports same formats.
Tiff format removed - there were some issues with opening such file. Further investigation needed if format is desired.
