### PR TITLE
Now, fixed all number inputs

### DIFF
--- a/PixiEditor/Views/UserControls/NumberInput.xaml
+++ b/PixiEditor/Views/UserControls/NumberInput.xaml
@@ -6,7 +6,7 @@
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              xmlns:behaviours="clr-namespace:PixiEditor.Helpers.Behaviours"
              mc:Ignorable="d"
-             d:DesignHeight="20" d:DesignWidth="40" x:Name="numberInput">
+             d:DesignHeight="20" d:DesignWidth="40" x:Name="numberInput" Focusable="True">
     <TextBox TextAlignment="Center" Style="{StaticResource DarkTextBoxStyle}" Focusable="True"
              InputScope="Number" MouseWheel="TextBox_MouseWheel"
              PreviewTextInput="TextBox_PreviewTextInput" Text="{Binding ElementName=numberInput, Path=Value}" Padding="0" VerticalContentAlignment="Center">


### PR DESCRIPTION
Now all NumberInputs lose focus correctly.

Becuase TextBoxFocusBehavior changes Focus element to first parent that is focusable. This all works, but NumberInput didn't have any focusable element within the control, so sometimes it worked, sometimes not, depending where NumberInput was. My change fixes that.