### PR TITLE
Prevented drag drop race condition

### DIFF
--- a/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
@@ -45,17 +45,19 @@ namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
         /// </summary>
         public void SaveToolbarSettings()
         {
-            for (int i = 0; i < Settings.Count; i++)
-            {
-                if (SharedSettings.Any(x => x.Name == Settings[i].Name))
-                {
-                    SharedSettings.First(x => x.Name == Settings[i].Name).Value = Settings[i].Value;
-                }
-                else
-                {
-                    SharedSettings.Add(Settings[i]);
-                }
-            }
+            //TODO: Setting
+
+            //for (int i = 0; i < Settings.Count; i++)
+            //{
+            //    if (SharedSettings.Any(x => x.Name == Settings[i].Name))
+            //    {
+            //        SharedSettings.First(x => x.Name == Settings[i].Name).Value = Settings[i].Value;
+            //    }
+            //    else
+            //    {
+            //        SharedSettings.Add(Settings[i]);
+            //    }
+            //}
         }
 
         /// <summary>
@@ -63,13 +65,15 @@ namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
         /// </summary>
         public void LoadSharedSettings()
         {
-            for (int i = 0; i < SharedSettings.Count; i++)
-            {
-                if (Settings.Any(x => x.Name == SharedSettings[i].Name))
-                {
-                    Settings.First(x => x.Name == SharedSettings[i].Name).Value = SharedSettings[i].Value;
-                }
-            }
+            //TODO: Setting
+
+            //for (int i = 0; i < SharedSettings.Count; i++)
+            //{
+            //    if (Settings.Any(x => x.Name == SharedSettings[i].Name))
+            //    {
+            //        Settings.First(x => x.Name == SharedSettings[i].Name).Value = SharedSettings[i].Value;
+            //    }
+            //}
         }
     }
 }

--- a/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
+++ b/PixiEditor/Models/Tools/ToolSettings/Toolbars/Toolbar.cs
@@ -45,19 +45,17 @@ namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
         /// </summary>
         public void SaveToolbarSettings()
         {
-            //TODO: Setting
-
-            //for (int i = 0; i < Settings.Count; i++)
-            //{
-            //    if (SharedSettings.Any(x => x.Name == Settings[i].Name))
-            //    {
-            //        SharedSettings.First(x => x.Name == Settings[i].Name).Value = Settings[i].Value;
-            //    }
-            //    else
-            //    {
-            //        SharedSettings.Add(Settings[i]);
-            //    }
-            //}
+            for (int i = 0; i < Settings.Count; i++)
+            {
+                if (SharedSettings.Any(x => x.Name == Settings[i].Name))
+                {
+                    SharedSettings.First(x => x.Name == Settings[i].Name).Value = Settings[i].Value;
+                }
+                else
+                {
+                    SharedSettings.Add(Settings[i]);
+                }
+            }
         }
 
         /// <summary>
@@ -65,15 +63,13 @@ namespace PixiEditor.Models.Tools.ToolSettings.Toolbars
         /// </summary>
         public void LoadSharedSettings()
         {
-            //TODO: Setting
-
-            //for (int i = 0; i < SharedSettings.Count; i++)
-            //{
-            //    if (Settings.Any(x => x.Name == SharedSettings[i].Name))
-            //    {
-            //        Settings.First(x => x.Name == SharedSettings[i].Name).Value = SharedSettings[i].Value;
-            //    }
-            //}
+            for (int i = 0; i < SharedSettings.Count; i++)
+            {
+                if (Settings.Any(x => x.Name == SharedSettings[i].Name))
+                {
+                    Settings.First(x => x.Name == SharedSettings[i].Name).Value = SharedSettings[i].Value;
+                }
+            }
         }
     }
 }

--- a/PixiEditor/ViewModels/SubViewModels/Main/ToolsViewModel.cs
+++ b/PixiEditor/ViewModels/SubViewModels/Main/ToolsViewModel.cs
@@ -5,6 +5,7 @@ using PixiEditor.Models.Events;
 using PixiEditor.Models.Tools;
 using PixiEditor.Models.Tools.Tools;
 using PixiEditor.Models.Tools.ToolSettings.Settings;
+using PixiEditor.Models.UserPreferences;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -104,7 +105,10 @@ namespace PixiEditor.ViewModels.SubViewModels.Main
 
             ActiveTool = tool;
 
-            ActiveTool.Toolbar.LoadSharedSettings();
+            if (IPreferences.Current.GetPreference<bool>("EnableSharedToolbar"))
+            {
+                ActiveTool.Toolbar.LoadSharedSettings();
+            }
 
             if (LastActionTool != ActiveTool)
                 SelectedToolChanged?.Invoke(this, new SelectedToolEventArgs(LastActionTool, ActiveTool));

--- a/PixiEditor/ViewModels/SubViewModels/UserPreferences/Settings/ToolsSettings.cs
+++ b/PixiEditor/ViewModels/SubViewModels/UserPreferences/Settings/ToolsSettings.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PixiEditor.ViewModels.SubViewModels.UserPreferences.Settings
+{
+    public class ToolsSettings : SettingsGroup
+    {
+        private bool enableSharedToolbar = GetPreference(nameof(EnableSharedToolbar), false);
+
+        public bool EnableSharedToolbar
+        {
+            get => enableSharedToolbar;
+            set
+            {
+                enableSharedToolbar = value;
+                RaiseAndUpdatePreference(nameof(EnableSharedToolbar), value);
+            }
+        }
+    }
+}

--- a/PixiEditor/ViewModels/SubViewModels/UserPreferences/SettingsViewModel.cs
+++ b/PixiEditor/ViewModels/SubViewModels/UserPreferences/SettingsViewModel.cs
@@ -6,6 +6,8 @@ namespace PixiEditor.ViewModels.SubViewModels.UserPreferences
     {
         public GeneralSettings General { get; set; } = new GeneralSettings();
 
+        public ToolsSettings Tools { get; set; } = new ToolsSettings();
+
         public FileSettings File { get; set; } = new FileSettings();
 
         public UpdateSettings Update { get; set; } = new UpdateSettings();

--- a/PixiEditor/Views/Dialogs/SettingsWindow.xaml
+++ b/PixiEditor/Views/Dialogs/SettingsWindow.xaml
@@ -76,6 +76,8 @@
                     <RowDefinition Height="{Binding RelativeSource={RelativeSource AncestorType=Grid}, Path=Tag}"/>
                     <RowDefinition Height="{Binding RelativeSource={RelativeSource AncestorType=Grid}, Path=Tag}"/>
                     <RowDefinition Height="{Binding RelativeSource={RelativeSource AncestorType=Grid}, Path=Tag}"/>
+                    <RowDefinition Height="{Binding RelativeSource={RelativeSource AncestorType=Grid}, Path=Tag}"/>
+                    <RowDefinition Height="{Binding RelativeSource={RelativeSource AncestorType=Grid}, Path=Tag}"/>
                 </Grid.RowDefinitions>
 
                 <Label Grid.Row="0" Grid.ColumnSpan="2" Style="{StaticResource SettingsHeader}">Misc</Label>
@@ -106,13 +108,18 @@
                                  Size="{Binding SettingsSubViewModel.File.DefaultNewFileHeight, Mode=TwoWay}" 
                                  Width="70" Height="21" MaxSize="9999" HorizontalAlignment="Left"/>
 
-                <Label Grid.Row="7" Grid.ColumnSpan="2" Style="{StaticResource SettingsHeader}">Automatic updates</Label>
+                <Label Grid.Row="7" Grid.ColumnSpan="2" Style="{StaticResource SettingsHeader}">Tools</Label>
 
                 <CheckBox Grid.Row="8" Grid.Column="1" VerticalAlignment="Center"
+                    IsChecked="{Binding SettingsSubViewModel.Tools.EnableSharedToolbar}">Enable shared toolbar</CheckBox>
+                
+                <Label Grid.Row="9" Grid.ColumnSpan="2" Style="{StaticResource SettingsHeader}">Automatic updates</Label>
+
+                <CheckBox Grid.Row="10" Grid.Column="1" VerticalAlignment="Center"
                     IsChecked="{Binding SettingsSubViewModel.Update.CheckUpdatesOnStartup}">Check updates on startup</CheckBox>
 
-                <Label Grid.Row="9" Grid.Column="1" Style="{StaticResource SettingsText}">Update stream</Label>
-                <ComboBox Grid.Row="9" Grid.Column="2" VerticalAlignment="Center"
+                <Label Grid.Row="11" Grid.Column="1" Style="{StaticResource SettingsText}">Update stream</Label>
+                <ComboBox Grid.Row="11" Grid.Column="2" VerticalAlignment="Center"
                     Width="110" Height="22" HorizontalAlignment="Left"
                     ItemsSource="{Binding SettingsSubViewModel.Update.UpdateChannels}"
                     SelectedValue="{Binding SettingsSubViewModel.Update.UpdateChannelName}"/>

--- a/PixiEditor/Views/UserControls/Layers/LayersManager.xaml.cs
+++ b/PixiEditor/Views/UserControls/Layers/LayersManager.xaml.cs
@@ -285,7 +285,8 @@ namespace PixiEditor.Views.UserControls.Layers
 
         private void LayerStructureItemContainer_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            if (sender is LayerStructureItemContainer container && e.LeftButton == System.Windows.Input.MouseButtonState.Pressed)
+            if (sender is LayerStructureItemContainer container
+                && e.LeftButton == System.Windows.Input.MouseButtonState.Pressed && !container.Layer.IsRenaming)
             {
                 Dispatcher.InvokeAsync(() => DragDrop.DoDragDrop(container, container, DragDropEffects.Move));
             }
@@ -332,7 +333,8 @@ namespace PixiEditor.Views.UserControls.Layers
 
         private void LayerGroup_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            if (sender is LayerGroupControl container && e.LeftButton == System.Windows.Input.MouseButtonState.Pressed)
+            if (sender is LayerGroupControl container && e.LeftButton == System.Windows.Input.MouseButtonState.Pressed
+                && !container.GroupData.IsRenaming)
             {
                 Dispatcher.InvokeAsync(() => DragDrop.DoDragDrop(container, container, DragDropEffects.Move));
             }
@@ -370,7 +372,6 @@ namespace PixiEditor.Views.UserControls.Layers
             }
 
             ShortcutController.UnblockShortcutExecutionAll();
-            MoveFocus(new System.Windows.Input.TraversalRequest(System.Windows.Input.FocusNavigationDirection.Next));
         }
 
         private void HandleLayerOpacityChange(float val, Layer layer)


### PR DESCRIPTION
The bug was caused by drag drop of textbox selection (inside layer or group name). PixiEditor tried to drag drop layer when textbox was already drag dropping. This caused WPF to freak out.

Repro of fixed bug:
1. Select word 'Base' in 'Base Layer'
2. Try drag dropping outside layer 


Also disabled shared toolbar