### PR TITLE
Fix focus loss if size text is selected in settings view

### DIFF
--- a/PixiEditor/Views/UserControls/SizeInput.xaml
+++ b/PixiEditor/Views/UserControls/SizeInput.xaml
@@ -48,6 +48,7 @@
                     <behaviors:TextBoxFocusBehavior 
                         SelectOnMouseClick="{Binding BehaveLikeSmallEmbeddedField, ElementName=uc}" 
                         ConfirmOnEnter="{Binding BehaveLikeSmallEmbeddedField, ElementName=uc}"
+                        FocusNext="True"
                         DeselectOnFocusLoss="True"/>
                 </i:Interaction.Behaviors>
             </TextBox>


### PR DESCRIPTION
Fix for  [#412](https://github.com/PixiEditor/PixiEditor/issues/412)

Focus the next view instead of main in size text boxes.
The color map loss of focus bug is part of the ColorPicker code and can not be fixed on this repo.