### PR TITLE
Fixed export filename crash

### DIFF
--- a/src/PixiEditor/Helpers/SupportedFilesHelper.cs
+++ b/src/PixiEditor/Helpers/SupportedFilesHelper.cs
@@ -36,6 +36,27 @@ internal class SupportedFilesHelper
         return allFileTypeDialogsData.Where(i => i.FileType == type).Single();
     }
 
+    public static string FixFileExtension(string pathWithOrWithoutExtension, FileType requestedType)
+    {
+        if (requestedType == FileType.Unset)
+            throw new ArgumentException("A valid filetype is required", nameof(requestedType));
+
+        var typeFromPath = SupportedFilesHelper.ParseImageFormat(Path.GetExtension(pathWithOrWithoutExtension));
+        if (typeFromPath != FileType.Unset && typeFromPath == requestedType)
+            return pathWithOrWithoutExtension;
+        return AppendExtension(pathWithOrWithoutExtension, SupportedFilesHelper.GetFileTypeDialogData(requestedType));
+    }
+
+    public static string AppendExtension(string path, FileTypeDialogData data)
+    {
+        string ext = data.Extensions.First();
+        string filename = Path.GetFileName(path);
+        if (filename.Length + ext.Length > 255)
+            filename = filename.Substring(0, 255 - ext.Length);
+        filename += ext;
+        return Path.Combine(Path.GetDirectoryName(path), filename);
+    }
+
     public static bool IsSupportedFile(string path)
     {
         var ext = Path.GetExtension(path.ToLower());

--- a/src/PixiEditor/Models/IO/Exporter.cs
+++ b/src/PixiEditor/Models/IO/Exporter.cs
@@ -67,23 +67,12 @@ internal class Exporter
     /// </summary>
     public static SaveResult TrySaveUsingDataFromDialog(DocumentViewModel document, string pathFromDialog, FileType fileTypeFromDialog, out string finalPath, VecI? exportSize = null)
     {
-        finalPath = FixFileExtension(pathFromDialog, fileTypeFromDialog);
+        finalPath = SupportedFilesHelper.FixFileExtension(pathFromDialog, fileTypeFromDialog);
         var saveResult = TrySave(document, finalPath, exportSize);
         if (saveResult != SaveResult.Success)
             finalPath = "";
 
         return saveResult;
-    }
-
-    private static string FixFileExtension(string pathWithOrWithoutExtension, FileType requestedType)
-    {
-        if (requestedType == FileType.Unset)
-            throw new ArgumentException("A valid filetype is required", nameof(requestedType));
-
-        var typeFromPath = SupportedFilesHelper.ParseImageFormat(Path.GetExtension(pathWithOrWithoutExtension));
-        if (typeFromPath != FileType.Unset && typeFromPath == requestedType)
-            return pathWithOrWithoutExtension;
-        return AppendExtension(pathWithOrWithoutExtension, SupportedFilesHelper.GetFileTypeDialogData(requestedType));
     }
 
     /// <summary>
@@ -118,16 +107,6 @@ internal class Exporter
         }
 
         return SaveResult.Success;
-    }
-
-    private static string AppendExtension(string path, FileTypeDialogData data)
-    {
-        string ext = data.Extensions.First();
-        string filename = Path.GetFileName(path);
-        if (filename.Length + ext.Length > 255)
-            filename = filename.Substring(0, 255 - ext.Length);
-        filename += ext;
-        return Path.Combine(Path.GetDirectoryName(path), filename);
     }
 
     static Dictionary<FileType, Func<BitmapEncoder>> encodersFactory = new Dictionary<FileType, Func<BitmapEncoder>>();

--- a/src/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
+++ b/src/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
@@ -66,12 +66,14 @@ internal class SaveFilePopupViewModel : ViewModelBase
         {
             if (string.IsNullOrEmpty(path.FileName) == false)
             {
-                ChosenFormat = SupportedFilesHelper.ParseImageFormat(Path.GetExtension(path.SafeFileName));
+                ChosenFormat = SupportedFilesHelper.GetSaveFileTypeFromFilterIndex(false, path.FilterIndex);
                 if (ChosenFormat == FileType.Unset)
                 {
-                    ChosenFormat = FileType.Png;
-                    path.FileName += ".png";
+                    return null;
                 }
+
+                path.FileName = SupportedFilesHelper.FixFileExtension(path.FileName, ChosenFormat);
+
                 return path.FileName;
             }
         }

--- a/src/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
+++ b/src/PixiEditor/ViewModels/SaveFilePopupViewModel.cs
@@ -59,13 +59,19 @@ internal class SaveFilePopupViewModel : ViewModelBase
             Title = "Export path",
             CheckPathExists = true,
             Filter = SupportedFilesHelper.BuildSaveFilter(false),
-            FilterIndex = 0
+            FilterIndex = 0,
+            AddExtension = true
         };
         if (path.ShowDialog() == true)
         {
             if (string.IsNullOrEmpty(path.FileName) == false)
             {
                 ChosenFormat = SupportedFilesHelper.ParseImageFormat(Path.GetExtension(path.SafeFileName));
+                if (ChosenFormat == FileType.Unset)
+                {
+                    ChosenFormat = FileType.Png;
+                    path.FileName += ".png";
+                }
                 return path.FileName;
             }
         }


### PR DESCRIPTION
For some reason, file dialog doesn't append extension for filename like "100.001" so PixiEditor couldn't detect extension. Simple fallback works here