### PR TITLE
Random improvements

### DIFF
--- a/src/ChunkyImageLib/Surface.cs
+++ b/src/ChunkyImageLib/Surface.cs
@@ -22,9 +22,7 @@ public class Surface : IDisposable
     public Surface(VecI size)
     {
         if (size.X < 1 || size.Y < 1)
-            throw new ArgumentException("Width and height must be >1");
-        if (size.X > 10000 || size.Y > 10000)
-            throw new ArgumentException("Width and height must be <=10000");
+            throw new ArgumentException("Width and height must be >=1");
 
         Size = size;
 

--- a/src/PixiEditor/Helpers/VersionHelpers.cs
+++ b/src/PixiEditor/Helpers/VersionHelpers.cs
@@ -14,77 +14,27 @@ internal static class VersionHelpers
     {
         StringBuilder builder = new(GetCurrentAssemblyVersion().ToString());
 
-        bool isDone = false;
-
-        AppendDevBuild(builder, ref isDone);
-        if (isDone)
-            return builder.ToString();
-
-        AppendMsixDebugBuild(builder, ref isDone);
-        if (isDone)
-            return builder.ToString();
-
-        AppendDebugBuild(builder, ref isDone);
-        if (isDone || !moreSpecific)
-            return builder.ToString();
-
-        AppendSteamBuild(builder, ref isDone);
-        if (isDone)
-            return builder.ToString();
-
-        AppendMsixBuild(builder, ref isDone);
-        if (isDone)
-            return builder.ToString();
-
-        AppendReleaseBuild(builder, ref isDone);
-        return builder.ToString();
-    }
-
-    [Conditional("DEVRELEASE")]
-    private static void AppendDevBuild(StringBuilder builder, ref bool done)
-    {
-        done = true;
-
+#if DEVRELEASE
         builder.Append(" Dev Build");
-    }
-
-    [Conditional("DEBUG")]
-    private static void AppendDebugBuild(StringBuilder builder, ref bool done)
-    {
-        done = true;
-
-        builder.Append(" Debug Build");
-    }
-
-    [Conditional("RELEASE")]
-    private static void AppendReleaseBuild(StringBuilder builder, ref bool done)
-    {
-        done = true;
-
-        builder.Append(" Release Build");
-    }
-
-    [Conditional("MSIX_DEBUG")]
-    private static void AppendMsixDebugBuild(StringBuilder builder, ref bool done)
-    {
-        done = true;
-
+        return builder.ToString();
+#elif MSIX_DEBUG
         builder.Append(" MSIX Debug Build");
-    }
+        return builder.ToString();
+#elif DEBUG
+        builder.Append(" Debug Build");
+        return builder.ToString();
+#endif
 
-    [Conditional("MSIX")]
-    private static void AppendMsixBuild(StringBuilder builder, ref bool done)
-    {
-        done = true;
+        if (!moreSpecific)
+            return builder.ToString();
 
-        builder.Append(" MSIX Build");
-    }
-
-    [Conditional("STEAM")]
-    private static void AppendSteamBuild(StringBuilder builder, ref bool done)
-    {
-        done = true;
-
+#if STEAM
         builder.Append(" Steam Build");
+#elif MSIX
+        builder.Append(" MSIX Build");
+#elif RELEASE
+        builder.Append(" Release Build");
+#endif
+        return builder.ToString();
     }
 }

--- a/src/PixiEditor/Helpers/VersionHelpers.cs
+++ b/src/PixiEditor/Helpers/VersionHelpers.cs
@@ -10,21 +10,33 @@ internal static class VersionHelpers
 
     public static string GetCurrentAssemblyVersion(Func<Version, string> toString) => toString(GetCurrentAssemblyVersion());
 
-    public static string GetCurrentAssemblyVersionString()
+    public static string GetCurrentAssemblyVersionString(bool moreSpecific = false)
     {
         StringBuilder builder = new(GetCurrentAssemblyVersion().ToString());
 
         bool isDone = false;
 
         AppendDevBuild(builder, ref isDone);
-
         if (isDone)
-        {
             return builder.ToString();
-        }
+
+        AppendMsixDebugBuild(builder, ref isDone);
+        if (isDone)
+            return builder.ToString();
 
         AppendDebugBuild(builder, ref isDone);
+        if (isDone || !moreSpecific)
+            return builder.ToString();
 
+        AppendSteamBuild(builder, ref isDone);
+        if (isDone)
+            return builder.ToString();
+
+        AppendMsixBuild(builder, ref isDone);
+        if (isDone)
+            return builder.ToString();
+
+        AppendReleaseBuild(builder, ref isDone);
         return builder.ToString();
     }
 
@@ -42,5 +54,37 @@ internal static class VersionHelpers
         done = true;
 
         builder.Append(" Debug Build");
+    }
+
+    [Conditional("RELEASE")]
+    private static void AppendReleaseBuild(StringBuilder builder, ref bool done)
+    {
+        done = true;
+
+        builder.Append(" Release Build");
+    }
+
+    [Conditional("MSIX_DEBUG")]
+    private static void AppendMsixDebugBuild(StringBuilder builder, ref bool done)
+    {
+        done = true;
+
+        builder.Append(" MSIX Debug Build");
+    }
+
+    [Conditional("MSIX")]
+    private static void AppendMsixBuild(StringBuilder builder, ref bool done)
+    {
+        done = true;
+
+        builder.Append(" MSIX Build");
+    }
+
+    [Conditional("STEAM")]
+    private static void AppendSteamBuild(StringBuilder builder, ref bool done)
+    {
+        done = true;
+
+        builder.Append(" Steam Build");
     }
 }

--- a/src/PixiEditor/Models/Commands/CommandController.cs
+++ b/src/PixiEditor/Models/Commands/CommandController.cs
@@ -282,15 +282,31 @@ internal class CommandController
 
             var parameters = method?.GetParameters();
 
-            Action<object> action;
+            async void ActionOnException(Task faultedTask)
+            {
+                // since this method is "async void" and not "async Task", the runtime will propagate exceptions out if it
+                // (instead of putting them into the returned task and forgetting about them)
+                await faultedTask; // this instantly throws the exception from the already faulted task
+            }
 
+            Action<object> action;
             if (parameters is not { Length: 1 })
             {
-                action = x => method.Invoke(instance, null);
+                action = x =>
+                {
+                    object result = method.Invoke(instance, null);
+                    if (result is Task task)
+                        task.ContinueWith(ActionOnException, TaskContinuationOptions.OnlyOnFaulted);
+                };
             }
             else
             {
-                action = x => method.Invoke(instance, new[] { x });
+                action = x =>
+                {
+                    object result = method.Invoke(instance, new[] { x });
+                    if (result is Task task)
+                        task.ContinueWith(ActionOnException, TaskContinuationOptions.OnlyOnFaulted);
+                };
             }
 
             string name = attribute.InternalName;

--- a/src/PixiEditor/Models/DataHolders/CrashReport.cs
+++ b/src/PixiEditor/Models/DataHolders/CrashReport.cs
@@ -19,7 +19,7 @@ internal class CrashReport : IDisposable
         DateTime currentTime = DateTime.Now;
 
         builder
-            .AppendLine($"PixiEditor {VersionHelpers.GetCurrentAssemblyVersionString()} crashed on {currentTime:yyyy.MM.dd} at {currentTime:HH:mm:ss}\n")
+            .AppendLine($"PixiEditor {VersionHelpers.GetCurrentAssemblyVersionString(moreSpecific: true)} crashed on {currentTime:yyyy.MM.dd} at {currentTime:HH:mm:ss}\n")
             .AppendLine("-----System Information----")
             .AppendLine("General:")
             .AppendLine($"  OS: {Environment.OSVersion.VersionString}")

--- a/src/PixiEditor/Models/IO/Exporter.cs
+++ b/src/PixiEditor/Models/IO/Exporter.cs
@@ -1,6 +1,8 @@
 ﻿using System.IO;
 using System.IO.Compression;
+using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Windows;
 using System.Windows.Media.Imaging;
 using ChunkyImageLib;
@@ -22,8 +24,10 @@ internal enum DialogSaveResult
     Success = 0,
     InvalidPath = 1,
     ConcurrencyError = 2,
-    UnknownError = 3,
-    Cancelled = 4,
+    SecurityError = 3,
+    IoError = 4,
+    UnknownError = 5,
+    Cancelled = 6,
 }
 
 internal enum SaveResult
@@ -31,7 +35,9 @@ internal enum SaveResult
     Success = 0,
     InvalidPath = 1,
     ConcurrencyError = 2,
-    UnknownError = 3,
+    SecurityError = 3,
+    IoError = 4,
+    UnknownError = 5,
 }
 
 internal class Exporter
@@ -108,9 +114,8 @@ internal class Exporter
             {
                 return SaveResult.UnknownError;
             }
-            
-            if (!TrySaveAs(encodersFactory[typeFromPath](), pathWithExtension, bitmap, exportSize))
-                return SaveResult.UnknownError;
+
+            return TrySaveAs(encodersFactory[typeFromPath](), pathWithExtension, bitmap, exportSize);
         }
         else
         {
@@ -170,7 +175,7 @@ internal class Exporter
     /// <summary>
     /// Saves image to PNG file. Messes with the passed bitmap.
     /// </summary>
-    private static bool TrySaveAs(BitmapEncoder encoder, string savePath, Surface bitmap, VecI? exportSize)
+    private static SaveResult TrySaveAs(BitmapEncoder encoder, string savePath, Surface bitmap, VecI? exportSize)
     {
         try
         {
@@ -184,10 +189,18 @@ internal class Exporter
             encoder.Frames.Add(BitmapFrame.Create(bitmap.ToWriteableBitmap()));
             encoder.Save(stream);
         }
-        catch (Exception err)
+        catch (SecurityException)
         {
-            return false;
+            return SaveResult.SecurityError;
         }
-        return true;
+        catch (IOException)
+        {
+            return SaveResult.IoError;
+        }
+        catch
+        {
+            return SaveResult.UnknownError;
+        }
+        return SaveResult.Success;
     }
 }

--- a/src/PixiEditor/ViewModels/CrashReportViewModel.cs
+++ b/src/PixiEditor/ViewModels/CrashReportViewModel.cs
@@ -40,25 +40,7 @@ internal class CrashReportViewModel : ViewModelBase
         AttachDebuggerCommand = new(AttachDebugger);
 
         if (!IsDebugBuild)
-            SendReportTextToWebhook(report);
-    }
-
-    private async void SendReportTextToWebhook(CrashReport report)
-    {
-        byte[] bytes = Encoding.UTF8.GetBytes(report.ReportText);
-        string filename = Path.GetFileNameWithoutExtension(report.FilePath) + ".txt";
-
-        MultipartFormDataContent formData = new MultipartFormDataContent
-        {
-            { new ByteArrayContent(bytes, 0, bytes.Length), "crash-report", filename }
-        };
-        try
-        {
-            using HttpClient httpClient = new HttpClient();
-            string url = BuildConstants.CrashReportWebhookUrl;
-            await httpClient.PostAsync(url, formData);
-        }
-        catch { }
+            _ = CrashHelper.SendReportTextToWebhook(report);
     }
 
     public void RecoverDocuments(object args)

--- a/src/PixiEditor/ViewModels/SubViewModels/Main/DebugViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/Main/DebugViewModel.cs
@@ -36,22 +36,39 @@ internal class DebugViewModel : SubViewModel<ViewModelMain>
         UpdateDebugMode(preferences.GetPreference<bool>("IsDebugModeEnabled"));
     }
 
-    [Command.Debug("PixiEditor.Debug.OpenTempDirectory", @"%Temp%\PixiEditor", "Open Temp Directory", "Open Temp Directory", IconPath = "Folder.png")]
-    [Command.Debug("PixiEditor.Debug.OpenLocalAppDataDirectory", @"%LocalAppData%\PixiEditor", "Open Local AppData Directory", "Open Local AppData Directory", IconPath = "Folder.png")]
-    [Command.Debug("PixiEditor.Debug.OpenRoamingAppDataDirectory", @"%AppData%\PixiEditor", "Open Roaming AppData Directory", "Open Roaming AppData Directory", IconPath = "Folder.png")]
-    [Command.Debug("PixiEditor.Debug.OpenCrashReportsDirectory", @"%LocalAppData%\PixiEditor\crash_logs", "Open Crash Reports Directory", "Open Crash Reports Directory", IconPath = "Folder.png")]
     public static void OpenFolder(string path)
     {
-        string expandedPath = Environment.ExpandEnvironmentVariables(path);
-        if (!Directory.Exists(expandedPath))
+        if (!Directory.Exists(path))
         {
-            NoticeDialog.Show($"{expandedPath} does not exist.", "Location does not exist");
+            NoticeDialog.Show($"{path} does not exist.", "Location does not exist");
             return;
         }
 
         ProcessHelpers.ShellExecuteEV(path);
     }
-    
+
+    [Command.Debug("PixiEditor.Debug.OpenLocalAppDataDirectory", @"PixiEditor", "Open Local AppData Directory", "Open Local AppData Directory", IconPath = "Folder.png")]
+    [Command.Debug("PixiEditor.Debug.OpenCrashReportsDirectory", @"PixiEditor\crash_logs", "Open Crash Reports Directory", "Open Crash Reports Directory", IconPath = "Folder.png")]
+    public static void OpenLocalAppDataFolder(string subDirectory)
+    {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), subDirectory);
+        OpenFolder(path);
+    }
+
+    [Command.Debug("PixiEditor.Debug.OpenRoamingAppDataDirectory", @"PixiEditor", "Open Roaming AppData Directory", "Open Roaming AppData Directory", IconPath = "Folder.png")]
+    public static void OpenAppDataFolder(string subDirectory)
+    {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), subDirectory);
+        OpenFolder(path);
+    }
+
+    [Command.Debug("PixiEditor.Debug.OpenTempDirectory", @"PixiEditor", "Open Temp Directory", "Open Temp Directory", IconPath = "Folder.png")]
+    public static void OpenTempFolder(string subDirectory)
+    {
+        var path = Path.Combine(Path.GetTempPath(), subDirectory);
+        OpenFolder(path);
+    }
+
     [Command.Debug("PixiEditor.Debug.DumpAllCommands", "Dump All Commands", "Dump All Commands to a text file")]
     public void DumpAllCommands()
     {

--- a/src/PixiEditor/ViewModels/SubViewModels/Main/FileViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/Main/FileViewModel.cs
@@ -323,13 +323,19 @@ internal class FileViewModel : SubViewModel<ViewModelMain>
         switch (result)
         {
             case DialogSaveResult.InvalidPath:
-                NoticeDialog.Show("Error", "Couldn't save the file to the specified location");
+                NoticeDialog.Show(title: "Error", message: "Couldn't save the file to the specified location");
                 break;
             case DialogSaveResult.ConcurrencyError:
-                NoticeDialog.Show("Internal error", "An internal error occured while saving. Please try again.");
+                NoticeDialog.Show(title: "Internal error", message: "An internal error occured while saving. Please try again.");
+                break;
+            case DialogSaveResult.SecurityError:
+                NoticeDialog.Show(title: "Security error", message: "No rights to write to the specified location.");
+                break;
+            case DialogSaveResult.IoError:
+                NoticeDialog.Show(title: "IO error", message: "Error while writing to disk.");
                 break;
             case DialogSaveResult.UnknownError:
-                NoticeDialog.Show("Error", "An error occured while saving.");
+                NoticeDialog.Show(title: "Error", message: "An error occured while saving.");
                 break;
         }
     }

--- a/src/PixiEditor/ViewModels/SubViewModels/Main/FileViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/Main/FileViewModel.cs
@@ -368,6 +368,8 @@ internal class FileViewModel : SubViewModel<ViewModelMain>
 
         foreach (string path in paths)
         {
+            if (!File.Exists(path))
+                continue;
             documents.Add(new RecentlyOpenedDocument(path));
         }
 

--- a/src/PixiEditor/ViewModels/SubViewModels/Main/MiscViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/Main/MiscViewModel.cs
@@ -29,7 +29,7 @@ internal class MiscViewModel : SubViewModel<ViewModelMain>
         catch (Exception e)
         {
             NoticeDialog.Show(title: "Error", message: $"Couldn't open the address {url} in your default browser");
-            await CrashHelper.SendExceptionInfoToWebhook(e).Wait();
+            await CrashHelper.SendExceptionInfoToWebhook(e);
         }
     }
 }

--- a/src/PixiEditor/ViewModels/SubViewModels/Main/MiscViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/Main/MiscViewModel.cs
@@ -20,7 +20,7 @@ internal class MiscViewModel : SubViewModel<ViewModelMain>
     [Command.Basic("PixiEditor.Links.OpenRepository", "https://github.com/PixiEditor/PixiEditor", "Repository", "Open Repository", IconPath = "Globe.png")]
     [Command.Basic("PixiEditor.Links.OpenLicense", "https://github.com/PixiEditor/PixiEditor/blob/master/LICENSE", "License", "Open License", IconPath = "Globe.png")]
     [Command.Basic("PixiEditor.Links.OpenOtherLicenses", "https://pixieditor.net/docs/Third-party-licenses", "Third Party Licenses", "Open Third Party Licenses", IconPath = "Globe.png")]
-    public static void OpenHyperlink(string url)
+    public static async Task OpenHyperlink(string url)
     {
         try
         {
@@ -29,7 +29,7 @@ internal class MiscViewModel : SubViewModel<ViewModelMain>
         catch (Exception e)
         {
             NoticeDialog.Show(title: "Error", message: $"Couldn't open the address {url} in your default browser");
-            _ = CrashHelper.SendExceptionInfoToWebhook(e);
+            await CrashHelper.SendExceptionInfoToWebhook(e).Wait();
         }
     }
 }

--- a/src/PixiEditor/ViewModels/SubViewModels/Main/MiscViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/Main/MiscViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using PixiEditor.Helpers;
 using PixiEditor.Models.Commands.Attributes;
 using PixiEditor.Models.Commands.Attributes.Commands;
+using PixiEditor.Models.Dialogs;
 using PixiEditor.Views.Dialogs;
 
 namespace PixiEditor.ViewModels.SubViewModels.Main;
@@ -21,6 +22,13 @@ internal class MiscViewModel : SubViewModel<ViewModelMain>
     [Command.Basic("PixiEditor.Links.OpenOtherLicenses", "https://pixieditor.net/docs/Third-party-licenses", "Third Party Licenses", "Open Third Party Licenses", IconPath = "Globe.png")]
     public static void OpenHyperlink(string url)
     {
-        ProcessHelpers.ShellExecute(url);
+        try
+        {
+            ProcessHelpers.ShellExecute(url);
+        }
+        catch
+        {
+            NoticeDialog.Show(title: "Error", message: $"Couldn't open the address {url} in your default browser");
+        }
     }
 }

--- a/src/PixiEditor/ViewModels/SubViewModels/Main/MiscViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/Main/MiscViewModel.cs
@@ -26,9 +26,10 @@ internal class MiscViewModel : SubViewModel<ViewModelMain>
         {
             ProcessHelpers.ShellExecute(url);
         }
-        catch
+        catch (Exception e)
         {
             NoticeDialog.Show(title: "Error", message: $"Couldn't open the address {url} in your default browser");
+            _ = CrashHelper.SendExceptionInfoToWebhook(e);
         }
     }
 }


### PR DESCRIPTION
- [x] Crash reports now state whether the build came from steam, website, or msstore
- [x] #498 
- [x] #495
- [x] Catch "System.ComponentModel.Win32Exception: An error occurred trying to start process 'https://pixieditor.net' with working directory 'C:\Program Files (x86)\Steam\steamapps\common\PixiEditor'. Application not found"
- [x] Added a helper that send a stacktrace to the webhook in situations other that crashes. The idea is that in some cases it can be completely safe to catch all exceptions and just show and error to the user, but at the same time we'd wanna know what these exceptions are, because they can still be cause by our own bug. So in this case we can log the exception using the helper method.
- [x] Don't throw when trying to create surfaces larger than 10k x 10k
- [x] The recent file list doesn't show missing files anymore