### PR TITLE
Fixed brightness tool symmetry and added multi-layer magic wand support

### DIFF
--- a/src/ChunkyImageLib/ChunkyImage.cs
+++ b/src/ChunkyImageLib/ChunkyImage.cs
@@ -607,6 +607,17 @@ public class ChunkyImage : IReadOnlyChunkyImage, IDisposable
     }
 
     /// <exception cref="ObjectDisposedException">This image is disposed</exception>
+    public void EnqueueDrawPixel(VecI pos, PixelProcessor pixelProcessor, BlendMode blendMode)
+    {
+        lock (lockObject)
+        {
+            ThrowIfDisposed();
+            PixelOperation operation = new(pos, pixelProcessor, blendMode);
+            EnqueueOperation(operation);
+        }
+    }
+
+    /// <exception cref="ObjectDisposedException">This image is disposed</exception>
     public void EnqueueDrawChunkyImage(VecI pos, ChunkyImage image, bool flipHor = false, bool flipVer = false)
     {
         lock (lockObject)

--- a/src/ChunkyImageLib/Operations/PixelOperation.cs
+++ b/src/ChunkyImageLib/Operations/PixelOperation.cs
@@ -68,7 +68,7 @@ internal class PixelOperation : IMirroredDrawOperation
         if (verAxisX is not null)
             pixelRect = (RectI)pixelRect.ReflectX((double)verAxisX).Round();
         if (horAxisY is not null)
-            pixelRect = pixelRect.ReflectY((int)horAxisY);
+            pixelRect = (RectI)pixelRect.ReflectY((double)horAxisY);
         if (_colorProcessor != null)
         {
             return new PixelOperation(pixelRect.Pos, _colorProcessor, blendMode);

--- a/src/PixiEditor.ChangeableDocument/Changes/Drawing/ChangeBrightness_UpdateableChange.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Drawing/ChangeBrightness_UpdateableChange.cs
@@ -88,9 +88,14 @@ internal class ChangeBrightness_UpdateableChange : UpdateableChange
             
             for (VecI pos = new VecI(left.X, y); pos.X <= right.X; pos.X++)
             {
-                Color pixel = tempSurface.GetSRGBPixel(pos);
-                Color newColor = ColorHelper.ChangeColorBrightness(pixel, correctionFactor);
-                layerImage.EnqueueDrawPixel(pos + offset, newColor, BlendMode.Src);
+                layerImage.EnqueueDrawPixel(
+                    pos + offset,
+                    (pixel) =>
+                    {
+                        Color newColor = ColorHelper.ChangeColorBrightness(pixel, correctionFactor);
+                        return ColorHelper.ChangeColorBrightness(newColor, correctionFactor);
+                    },
+                    BlendMode.Src);
             }
         }
     }

--- a/src/PixiEditor.ChangeableDocument/Changes/Selection/MagicWand/MagicWand_Change.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Selection/MagicWand/MagicWand_Change.cs
@@ -10,18 +10,16 @@ internal class MagicWand_Change : Change
     private VectorPath? originalPath;
     private VectorPath path = new() { FillType = PathFillType.EvenOdd };
     private VecI point;
-    private readonly Guid memberGuid;
-    private readonly bool referenceAll;
+    private readonly List<Guid> memberGuids;
     private readonly bool drawOnMask;
     private readonly SelectionMode mode;
 
     [GenerateMakeChangeAction]
-    public MagicWand_Change(Guid memberGuid, VecI point, SelectionMode mode, bool referenceAll, bool drawOnMask)
+    public MagicWand_Change(List<Guid> memberGuids, VecI point, SelectionMode mode, bool drawOnMask)
     {
         path.MoveTo(point);
         this.mode = mode;
-        this.memberGuid = memberGuid;
-        this.referenceAll = referenceAll;
+        this.memberGuids = memberGuids;
         this.drawOnMask = drawOnMask;
         this.point = point;
     }
@@ -34,13 +32,14 @@ internal class MagicWand_Change : Change
 
     public override OneOf<None, IChangeInfo, List<IChangeInfo>> Apply(Document target, bool firstApply, out bool ignoreInUndo)
     {
-        var image = DrawingChangeHelper.GetTargetImageOrThrow(target, memberGuid, drawOnMask);
-
         HashSet<Guid> membersToReference = new();
-        if (referenceAll)
-            target.ForEveryReadonlyMember(member => membersToReference.Add(member.GuidValue));
-        else
-            membersToReference.Add(memberGuid);
+
+        target.ForEveryReadonlyMember(member =>
+        {
+            if (memberGuids.Contains(member.GuidValue))
+                membersToReference.Add(member.GuidValue);
+        });
+
         path = MagicWandHelper.DoMagicWandFloodFill(point, membersToReference, target);
 
         ignoreInUndo = false;

--- a/src/PixiEditor.ChangeableDocument/Changes/Selection/MagicWand/MagicWand_Change.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Selection/MagicWand/MagicWand_Change.cs
@@ -11,16 +11,14 @@ internal class MagicWand_Change : Change
     private VectorPath path = new() { FillType = PathFillType.EvenOdd };
     private VecI point;
     private readonly List<Guid> memberGuids;
-    private readonly bool drawOnMask;
     private readonly SelectionMode mode;
 
     [GenerateMakeChangeAction]
-    public MagicWand_Change(List<Guid> memberGuids, VecI point, SelectionMode mode, bool drawOnMask)
+    public MagicWand_Change(List<Guid> memberGuids, VecI point, SelectionMode mode)
     {
         path.MoveTo(point);
         this.mode = mode;
         this.memberGuids = memberGuids;
-        this.drawOnMask = drawOnMask;
         this.point = point;
     }
 

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/MagicWandToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/MagicWandToolExecutor.cs
@@ -29,7 +29,7 @@ internal class MagicWandToolExecutor : UpdateableChangeExecutor
             memberGuids = document!.StructureHelper.GetAllLayers().Select(x => x.GuidValue).ToList();
         var pos = controller!.LastPixelPosition;
 
-        internals!.ActionAccumulator.AddActions(new MagicWand_Action(memberGuids, pos, mode, considerAllLayers));
+        internals!.ActionAccumulator.AddActions(new MagicWand_Action(memberGuids, pos, mode));
 
         return ExecutionState.Success;
     }


### PR DESCRIPTION
- [x] #440  Addd pixel processor func to PixelOperation which acts a little like a post-process for pixels, so PixelOperation can be a little more dynamic. This fixes the issue with brightness tool symmetry
- [x] #477 