### PR TITLE
Absolute path to data resolving

### DIFF
--- a/src/PixiEditor/Localization/LocalizationProvider.cs
+++ b/src/PixiEditor/Localization/LocalizationProvider.cs
@@ -1,6 +1,8 @@
 ﻿using System.Globalization;
 using System.IO;
+using System.Reflection;
 using Newtonsoft.Json;
+using PixiEditor.Models.IO;
 using PixiEditor.Models.UserPreferences;
 
 namespace PixiEditor.Localization;
@@ -8,7 +10,7 @@ namespace PixiEditor.Localization;
 internal class LocalizationProvider : ILocalizationProvider
 {
     private Language debugLanguage;
-    public string LocalizationDataPath { get; } = Path.Combine("Data", "Localization", "LocalizationData.json");
+    public string LocalizationDataPath { get; } = Path.Combine(Paths.DataFullPath, "Localization", "LocalizationData.json");
     public LocalizationData LocalizationData { get; private set; }
     public Language CurrentLanguage { get; set; }
     public LanguageData SelectedLanguage { get; private set; }
@@ -95,7 +97,7 @@ internal class LocalizationProvider : ILocalizationProvider
 
     private Language LoadLanguageInternal(LanguageData languageData)
     {
-        string localePath = Path.Combine("Data", "Localization", "Languages", languageData.LocaleFileName);
+        string localePath = Path.Combine(Paths.DataFullPath, "Localization", "Languages", languageData.LocaleFileName);
 
         if (!File.Exists(localePath))
         {

--- a/src/PixiEditor/Models/Commands/Templates/Providers/Parsers/KeysParser.cs
+++ b/src/PixiEditor/Models/Commands/Templates/Providers/Parsers/KeysParser.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Newtonsoft.Json;
+using PixiEditor.Models.IO;
 
 namespace PixiEditor.Models.Commands.Templates.Parsers;
 
@@ -17,7 +18,7 @@ public abstract class KeysParser
     
     public KeysParser(string mapFileName)
     {
-        _fullMapFilePath = Path.Combine("Data", "ShortcutActionMaps", mapFileName);
+        _fullMapFilePath = Path.Combine(Paths.DataFullPath, "ShortcutActionMaps", mapFileName);
         if (!File.Exists(_fullMapFilePath))
         {
             throw new FileNotFoundException($"Keys map file '{_fullMapFilePath}' not found.");

--- a/src/PixiEditor/Models/IO/Paths.cs
+++ b/src/PixiEditor/Models/IO/Paths.cs
@@ -1,0 +1,8 @@
+﻿using System.IO;
+using System.Reflection;
+
+namespace PixiEditor.Models.IO;
+public static class Paths
+{
+    public static string DataFullPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Data");
+}


### PR DESCRIPTION
I noticed that while testing PixiEditor.MSIX, working directory for some reason was one level below PixiEditor.exe, some MSIX file was executing it? Therefore it crashed because it couldn't find `Data` folder. Anyway, not sure if that happens in actual Microsoft Store version, even if not, this is a fix for debug configurations while testing.