### PR TITLE
Fix Jasc PSP palette parser

### DIFF
--- a/src/PixiEditor/Models/IO/PaletteParsers/JascPalFile/JascFileParser.cs
+++ b/src/PixiEditor/Models/IO/PaletteParsers/JascPalFile/JascFileParser.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using PixiEditor.DrawingApi.Core.ColorsImpl;
 using PixiEditor.Extensions.Palettes;
 using PixiEditor.Extensions.Palettes.Parsers;
 
@@ -10,7 +9,7 @@ namespace PixiEditor.Models.IO.PaletteParsers.JascPalFile;
 /// </summary>
 internal class JascFileParser : PaletteFileParser
 {
-    private static readonly string[] _supportedFileExtensions = new string[] { ".pal" };
+    private static readonly string[] _supportedFileExtensions = new string[] { ".pal", ".psppalette" };
     public override string[] SupportedFileExtensions => _supportedFileExtensions;
     public override string FileName => "Jasc Palette";
 


### PR DESCRIPTION
Since at least v20, Paint Shop Pro palette extensions default to ".PspPalette". For compatibility sake, I've add this extension to the parser so these files can be imported as well. Corel still uses the same old data format as JASC for these files so no other changes need be made. I've tested with the current version 2023. Export will still default to the .pal extension. 