### PR TITLE
Selecting the closest layer when deleting

### DIFF
--- a/src/PixiEditor/Models/DocumentModels/Public/DocumentStructureModule.cs
+++ b/src/PixiEditor/Models/DocumentModels/Public/DocumentStructureModule.cs
@@ -100,6 +100,37 @@ internal class DocumentStructureModule
         return layers;
     }
 
+    public List<StructureMemberViewModel> GetAllMembers()
+    {
+        List<StructureMemberViewModel> layers = new List<StructureMemberViewModel>();
+        foreach (StructureMemberViewModel? member in doc.StructureRoot.Children)
+        {
+            if (member is LayerViewModel layer)
+                layers.Add(layer);
+            else if (member is FolderViewModel folder)
+            {
+                layers.Add(folder);
+            }
+        }
+        return layers;
+    }
+
+
+    private List<StructureMemberViewModel> GetAllMembers(FolderViewModel folder, List<StructureMemberViewModel> layers)
+    {
+        foreach (StructureMemberViewModel? member in folder.Children)
+        {
+            if (member is LayerViewModel layer)
+                layers.Add(layer);
+            else if (member is FolderViewModel innerFolder)
+            {
+                layers.Add(innerFolder);
+                layers.AddRange(GetAllMembers(innerFolder, layers));
+            }
+        }
+        return layers;
+    }
+
     private bool FillPath(FolderViewModel folder, Guid guid, List<StructureMemberViewModel> toFill)
     {
         if (folder.GuidValue == guid)

--- a/src/PixiEditor/Models/DocumentModels/Public/DocumentStructureModule.cs
+++ b/src/PixiEditor/Models/DocumentModels/Public/DocumentStructureModule.cs
@@ -115,7 +115,6 @@ internal class DocumentStructureModule
         return layers;
     }
 
-
     private List<StructureMemberViewModel> GetAllMembers(FolderViewModel folder, List<StructureMemberViewModel> layers)
     {
         foreach (StructureMemberViewModel? member in folder.Children)

--- a/src/PixiEditor/ViewModels/SubViewModels/Main/LayersViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/Main/LayersViewModel.cs
@@ -84,9 +84,7 @@ internal class LayersViewModel : SubViewModel<ViewModelMain>
 
                         break;
                 }
-
-            }
-
+             }
             doc.Operations.AddSoftSelectedMember(baseLayer.GuidValue);
             doc.InternalSetSelectedMember(baseLayer);
         }

--- a/src/PixiEditor/ViewModels/SubViewModels/Main/LayersViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/Main/LayersViewModel.cs
@@ -58,28 +58,30 @@ internal class LayersViewModel : SubViewModel<ViewModelMain>
 
         member.Document.Operations.DeleteStructureMember(member.GuidValue);
 
-        if (doc.StructureHelper.GetAllLayers().Count > 1)
+        var allLayers = doc.StructureHelper.GetAllLayers().ToArray();
+
+        if (allLayers.Length > 1)
         {
             //Declare the layer that will be selected
-             var baseLayer = doc.StructureHelper.GetAllLayers()[doc.StructureHelper.GetAllLayers().ToArray().Length - 1];
+             var baseLayer = allLayers[allLayers.ToArray().Length - 1];
         
-             for (int i = 0; i < doc.StructureHelper.GetAllLayers().Count; i++)
+             for (int i = 0; i <allLayers.Length; i++)
             {
                 //Checking that the selected layer and the deleted layer are not the same
-                if (doc.StructureHelper.GetAllLayers()[i] == member)
+                if (allLayers[i] == member)
                 {
                     //Selecting the new layer
                     if (i > 0)
                     {
-                        baseLayer = doc.StructureHelper.GetAllLayers()[i-1];
+                        baseLayer = allLayers[i - 1];
                     }
-                    else if (i == doc.StructureHelper.GetAllLayers().Count - 1) 
+                    else if (i == allLayers.Length - 1) 
                     {
-                        baseLayer = doc.StructureHelper.GetAllLayers()[i];
+                        baseLayer = allLayers[i];
                     }
                     else if (i == 0)
                     {
-                        baseLayer = doc.StructureHelper.GetAllLayers().ToArray()[i+1];
+                        baseLayer = allLayers[i + 1];
                     }
 
                         break;

--- a/src/PixiEditor/ViewModels/SubViewModels/Main/LayersViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/Main/LayersViewModel.cs
@@ -67,14 +67,12 @@ internal class LayersViewModel : SubViewModel<ViewModelMain>
 
         //Checking if the length is greater than one, to avoid crashing.
         if (allLayers.Length > 0)
-        {
-           
+        {  
             for (int i = 0; i < allLayers.Length; i++)
             {
                 //Finding the layer that is being deleted
                 if (allLayers[i] == member)
                 {
-
                     //Selecting the new layer
                     if (i > 0)
                     {
@@ -94,9 +92,9 @@ internal class LayersViewModel : SubViewModel<ViewModelMain>
                 else
                 {
                     //Managing elements inside folders
-                    if (allLayers[i] is FolderViewModel _folder)
+                    if (allLayers[i] is FolderViewModel folder)
                     {
-                        var list = _folder.Children.OfType<StructureMemberViewModel>().ToArray();
+                        var list = folder.Children.OfType<StructureMemberViewModel>().ToArray();
 
                         if (list.Length > 1)
                         {


### PR DESCRIPTION
### Selecting the closest layer when deleting (similar to GIMP)


https://github.com/PixiEditor/PixiEditor/assets/23508114/255f9649-a95b-4e3e-8717-51b0b7fadb86

I noticed that when deleting a layer, there was no layer selected after, and this make working uncomfortable because you couldn't  draw after deleting a layer, and you had to manually select the layer you wanted to work with.

The logic used was: 
* Search in the list of layers in the project.
* Locate the layer that is being deleted.
* Select the next layer above or below depending on the position of the layer that is being deleted.
