### PR TITLE
Palette browser fixes

### DIFF
--- a/src/PixiEditor/Models/DataProviders/LocalPalettesFetcher.cs
+++ b/src/PixiEditor/Models/DataProviders/LocalPalettesFetcher.cs
@@ -4,6 +4,7 @@ using PixiEditor.Extensions.Common.Localization;
 using PixiEditor.Extensions.Common.UserPreferences;
 using PixiEditor.Extensions.Palettes;
 using PixiEditor.Extensions.Palettes.Parsers;
+using PixiEditor.Helpers;
 using PixiEditor.Models.DataHolders;
 using PixiEditor.Models.DataHolders.Palettes;
 using PixiEditor.Models.IO;
@@ -150,7 +151,7 @@ internal class LocalPalettesFetcher : PaletteListDataSource
     {
         string[] files = DirectoryExtensions.GetFiles(
             Paths.PathToPalettesFolder,
-            string.Join("|", AvailableParsers.SelectMany(x => x.SupportedFileExtensions)),
+            string.Join("|", AvailableParsers.SelectMany(x => x.SupportedFileExtensions).Distinct()),
             SearchOption.TopDirectoryOnly);
         cachedPalettes = await ParseAll(files);
         CacheUpdated?.Invoke(RefreshType.All, null, null);

--- a/src/PixiEditor/Models/DataProviders/LocalPalettesFetcher.cs
+++ b/src/PixiEditor/Models/DataProviders/LocalPalettesFetcher.cs
@@ -225,6 +225,7 @@ internal class LocalPalettesFetcher : PaletteListDataSource
         {
             await RefreshCacheAll();
             
+            // Using try-catch to generate stack trace
             try
             {
                 throw new NullReferenceException($"The '{nameof(updated)}' was null even though the refresh type was '{refreshType}'.");

--- a/src/PixiEditor/Models/DataProviders/LocalPalettesFetcher.cs
+++ b/src/PixiEditor/Models/DataProviders/LocalPalettesFetcher.cs
@@ -220,6 +220,23 @@ internal class LocalPalettesFetcher : PaletteListDataSource
             default:
                 throw new ArgumentOutOfRangeException(nameof(refreshType), refreshType, null);
         }
+
+        if (refreshType is RefreshType.Created or RefreshType.Updated && updated == null)
+        {
+            await RefreshCacheAll();
+            
+            try
+            {
+                throw new NullReferenceException($"The '{nameof(updated)}' was null even though the refresh type was '{refreshType}'.");
+            }
+            catch (Exception e)
+            {
+                await CrashHelper.SendExceptionInfoToWebhookAsync(e);
+            }
+
+            return;
+        }
+        
         CacheUpdated?.Invoke(refreshType, updated, affectedFileName);
     }
 

--- a/src/PixiEditor/Views/Dialogs/PalettesBrowser.xaml
+++ b/src/PixiEditor/Views/Dialogs/PalettesBrowser.xaml
@@ -50,8 +50,8 @@
         <DockPanel Background="{StaticResource MainColor}" Grid.Row="1">
             <StackPanel HorizontalAlignment="Left" Margin="10" Orientation="Horizontal" VerticalAlignment="Center">
                 <Label ui:Translator.Key="SORT_BY" Style="{StaticResource BaseLabel}" VerticalAlignment="Center"/>
-                <ComboBox x:Name="sortingComboBox" VerticalAlignment="Center" SelectionChanged="SortingComboBox_SelectionChanged">
-                    <ComboBoxItem IsSelected="True" ui:Translator.Key="DEFAULT"/>
+                <ComboBox x:Name="sortingComboBox" SelectedIndex="0" VerticalAlignment="Center" SelectionChanged="SortingComboBox_SelectionChanged">
+                    <ComboBoxItem ui:Translator.Key="DEFAULT"/>
                     <ComboBoxItem ui:Translator.Key="ALPHABETICAL"/>
                     <ComboBoxItem ui:Translator.Key="COLOR_COUNT"/>
                 </ComboBox>

--- a/src/PixiEditor/Views/Dialogs/PalettesBrowser.xaml.cs
+++ b/src/PixiEditor/Views/Dialogs/PalettesBrowser.xaml.cs
@@ -310,8 +310,16 @@ internal partial class PalettesBrowser : Window, IPopupWindow
 
     private void HandleCachePaletteCreated(Palette updatedItem)
     {
-        SortedResults.Add(updatedItem);
-        PaletteList.Palettes.Add(updatedItem);
+        if (!SortedResults.Contains(updatedItem))
+        {
+            SortedResults.Add(updatedItem);
+        }
+
+        if(!PaletteList.Palettes.Contains(updatedItem))
+        {
+            PaletteList.Palettes.Add(updatedItem);
+        }
+
         Sort();
     }
 


### PR DESCRIPTION
Fixed duplicate palettes in palette browser and "fixed" there being null's in the palette list by reloading all palettes if it happens