### PR TITLE
ThrowIf in TestClass

### DIFF
--- a/src/ChunkyImageLib/ChunkyImage.cs
+++ b/src/ChunkyImageLib/ChunkyImage.cs
@@ -1276,8 +1276,7 @@ public class ChunkyImage : IReadOnlyChunkyImage, IDisposable
 
     private void ThrowIfDisposed()
     {
-        if (disposed)
-            throw new ObjectDisposedException(nameof(ChunkyImage));
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 
     public void Dispose()

--- a/src/ChunkyImageLib/ChunkyImage.cs
+++ b/src/ChunkyImageLib/ChunkyImage.cs
@@ -1276,7 +1276,7 @@ public class ChunkyImage : IReadOnlyChunkyImage, IDisposable
 
     private void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(disposed, this);
     }
 
     public void Dispose()


### PR DESCRIPTION
Just doing what an issue on CodeFactor said to do.
"Use 'ObjectDisposedException.ThrowIf' instead of explicitly throwing a new exception instance."