### PR TITLE
Send OS to analytics and recover analytics session after crash

### DIFF
--- a/src/PixiEditor.Linux/LinuxOperatingSystem.cs
+++ b/src/PixiEditor.Linux/LinuxOperatingSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input;
 using Avalonia.Threading;
 using PixiEditor.OperatingSystem;
 
@@ -7,6 +8,8 @@ namespace PixiEditor.Linux;
 public sealed class LinuxOperatingSystem : IOperatingSystem
 {
     public string Name { get; } = "Linux";
+    public string AnalyticsId => "Linux";
+    public string AnalyticsName => LinuxOSInformation.FromReleaseFile().ToString();
     public IInputKeys InputKeys { get; }
     public IProcessUtility ProcessUtility { get; }
     
@@ -23,5 +26,44 @@ public sealed class LinuxOperatingSystem : IOperatingSystem
     public bool HandleNewInstance(Dispatcher? dispatcher, Action<string> openInExistingAction, IApplicationLifetime lifetime)
     {
         return true;
+    }
+
+    class LinuxOSInformation
+    {
+        const string FilePath = "/etc/os-release";
+        
+        private LinuxOSInformation(string? name, string? version, bool available)
+        {
+            Name = name;
+            Version = version;
+            Available = available;
+        }
+
+        public static LinuxOSInformation FromReleaseFile()
+        {
+            if (!File.Exists(FilePath))
+            {
+                return new LinuxOSInformation(null, null, false);
+            }
+            
+            var lines = File.ReadAllLines(FilePath).Select<string, (string Key, string Value)>(x =>
+            {
+                var separatorIndex = x.IndexOf('=');
+                return (x[..separatorIndex], x[(separatorIndex + 1)..]);
+            }).ToList();
+            
+            var name = lines.FirstOrDefault(x => x.Key == "NAME").Value.Trim('"');
+            var version = lines.FirstOrDefault(x => x.Key == "VERSION").Value.Trim('"');
+            
+            return new LinuxOSInformation(name, version, true);
+        }
+        
+        public bool Available { get; }
+        
+        public string? Name { get; private set; }
+        
+        public string? Version { get; private set; }
+
+        public override string ToString() => $"{Name} {Version}";
     }
 }

--- a/src/PixiEditor.Linux/LinuxOperatingSystem.cs
+++ b/src/PixiEditor.Linux/LinuxOperatingSystem.cs
@@ -46,6 +46,7 @@ public sealed class LinuxOperatingSystem : IOperatingSystem
                 return new LinuxOSInformation(null, null, false);
             }
             
+            // Parse /etc/os-release file (e.g. 'NAME="Ubuntu"')
             var lines = File.ReadAllLines(FilePath).Select<string, (string Key, string Value)>(x =>
             {
                 var separatorIndex = x.IndexOf('=');

--- a/src/PixiEditor.MacOs/MacOperatingSystem.cs
+++ b/src/PixiEditor.MacOs/MacOperatingSystem.cs
@@ -7,6 +7,9 @@ namespace PixiEditor.MacOs;
 public sealed class MacOperatingSystem : IOperatingSystem
 {
     public string Name { get; } = "MacOS";
+
+    public string AnalyticsId => "macOS";
+    
     public IInputKeys InputKeys { get; }
     public IProcessUtility ProcessUtility { get; }
     public void OpenUri(string uri)

--- a/src/PixiEditor.OperatingSystem/IOperatingSystem.cs
+++ b/src/PixiEditor.OperatingSystem/IOperatingSystem.cs
@@ -8,6 +8,9 @@ public interface IOperatingSystem
     public static IOperatingSystem Current { get; protected set; }
     public string Name { get; }
 
+    public virtual string AnalyticsName => Environment.OSVersion.ToString();
+    public string AnalyticsId { get; }
+
     public IInputKeys InputKeys { get; }
     public IProcessUtility ProcessUtility { get; }
 

--- a/src/PixiEditor.Windows/WindowsOperatingSystem.cs
+++ b/src/PixiEditor.Windows/WindowsOperatingSystem.cs
@@ -9,6 +9,9 @@ namespace PixiEditor.Windows;
 public sealed class WindowsOperatingSystem : IOperatingSystem
 {
     public string Name => "Windows";
+    
+    public string AnalyticsId => "Windows";
+    
     public IInputKeys InputKeys { get; } = new WindowsInputKeys();
     public IProcessUtility ProcessUtility { get; } = new WindowsProcessUtility();
     

--- a/src/PixiEditor/Exceptions/CommandInvocationException.cs
+++ b/src/PixiEditor/Exceptions/CommandInvocationException.cs
@@ -1,0 +1,7 @@
+﻿namespace PixiEditor.Exceptions;
+
+public class CommandInvocationException : Exception
+{
+    public CommandInvocationException(string commandName, Exception? innerException = null) : 
+        base($"Command '{commandName}' threw an exception", innerException) { }
+}

--- a/src/PixiEditor/Helpers/CrashHelper.cs
+++ b/src/PixiEditor/Helpers/CrashHelper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using ByteSizeLib;
 using Hardware.Info;
@@ -12,7 +13,7 @@ using PixiEditor.ViewModels.Document;
 
 namespace PixiEditor.Helpers;
 
-internal class CrashHelper
+internal partial class CrashHelper
 {
     private readonly IHardwareInfo hwInfo;
 
@@ -84,7 +85,7 @@ internal class CrashHelper
             .AppendLine("\n-------Crash message-------")
             .Append(e.GetType().ToString())
             .Append(": ")
-            .AppendLine(e.Message);
+            .AppendLine(TrimFilePaths(e.Message));
         {
             var innerException = e.InnerException;
             while (innerException != null)
@@ -93,7 +94,7 @@ internal class CrashHelper
                     .Append("\n-----Inner exception-----\n")
                     .Append(innerException.GetType().ToString())
                     .Append(": ")
-                    .Append(innerException.Message);
+                    .Append(TrimFilePaths(innerException.Message));
                 innerException = innerException.InnerException;
             }
         }
@@ -112,6 +113,8 @@ internal class CrashHelper
             }
         }
     }
+
+    private static string TrimFilePaths(string text) => FilePathRegex().Replace(text, "{{ FILE PATH }}");
     
     public static void SendExceptionInfoToWebhook(Exception e, bool wait = false,
         [CallerFilePath] string filePath = "<unknown>", [CallerMemberName] string memberName = "<unknown>")
@@ -156,4 +159,7 @@ internal class CrashHelper
         }
         catch { }
     }
+
+    [GeneratedRegex(@"'([^']*[\/\\][^']*)'|(\S*[\/\\]\S*)")]
+    private static partial Regex FilePathRegex();
 }

--- a/src/PixiEditor/Helpers/CrashHelper.cs
+++ b/src/PixiEditor/Helpers/CrashHelper.cs
@@ -160,6 +160,9 @@ internal partial class CrashHelper
         catch { }
     }
 
+    /// <summary>
+    /// Matches file paths with spaces when in quotes, otherwise not
+    /// </summary>
     [GeneratedRegex(@"'([^']*[\/\\][^']*)'|(\S*[\/\\]\S*)")]
     private static partial Regex FilePathRegex();
 }

--- a/src/PixiEditor/Models/AnalyticsAPI/AnalyticEventTypes.cs
+++ b/src/PixiEditor/Models/AnalyticsAPI/AnalyticEventTypes.cs
@@ -12,6 +12,7 @@ public class AnalyticEventTypes
     public static string GeneralCommand { get; } = GetEventType("GeneralCommand");
     public static string SwitchTool { get; } = GetEventType("SwitchTool");
     public static string UseTool { get; } = GetEventType("UseTool");
+    public static string ResumeSession { get; } = GetEventType("ResumeSession");
 
     private static string GetEventType(string value) => $"PixiEditor.{value}";
 }

--- a/src/PixiEditor/Models/AnalyticsAPI/AnalyticSessionInfo.cs
+++ b/src/PixiEditor/Models/AnalyticsAPI/AnalyticSessionInfo.cs
@@ -1,8 +1,14 @@
-﻿namespace PixiEditor.Models.AnalyticsAPI;
+﻿using PixiEditor.OperatingSystem;
 
-public class AnalyticSessionInfo
+namespace PixiEditor.Models.AnalyticsAPI;
+
+public class AnalyticSessionInfo(IOperatingSystem os)
 {
     public Version Version { get; set; }
 
     public string BuildId { get; set; }
+
+    public string? PlatformId { get; set; } = os.AnalyticsId;
+
+    public string? PlatformName { get; set; } = os.AnalyticsName;
 }

--- a/src/PixiEditor/Models/AnalyticsAPI/AnalyticsClient.cs
+++ b/src/PixiEditor/Models/AnalyticsAPI/AnalyticsClient.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using PixiEditor.Helpers;
 using PixiEditor.Models.Input;
 using PixiEditor.Numerics;
+using PixiEditor.OperatingSystem;
 
 namespace PixiEditor.Models.AnalyticsAPI;
 
@@ -31,9 +32,10 @@ public class AnalyticsClient
 
     public async Task<Guid?> CreateSessionAsync(CancellationToken cancellationToken = default)
     {
-        var session = new AnalyticSessionInfo()
+        var session = new AnalyticSessionInfo(IOperatingSystem.Current)
         {
-            Version = VersionHelpers.GetCurrentAssemblyVersion(), BuildId = VersionHelpers.GetBuildId()
+            Version = VersionHelpers.GetCurrentAssemblyVersion(),
+            BuildId = VersionHelpers.GetBuildId(),
         };
         
         var response = await _client.PostAsJsonAsync("sessions/new", session, _options, cancellationToken);

--- a/src/PixiEditor/Models/Commands/CommandController.cs
+++ b/src/PixiEditor/Models/Commands/CommandController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Avalonia.Media;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
+using PixiEditor.Exceptions;
 using PixiEditor.Helpers.Extensions;
 using PixiEditor.Extensions.Common.Localization;
 using PixiEditor.Models.AnalyticsAPI;
@@ -376,10 +377,17 @@ internal class CommandController
         {
             Analytics.SendCommand(name, (parameter as CommandExecutionContext)?.SourceInfo);
         }
-                
-        object result = method.Invoke(instance, parameters);
-        if (result is Task task)
-            task.ContinueWith(ActionOnException, TaskContinuationOptions.OnlyOnFaulted);
+
+        try
+        {
+            object result = method.Invoke(instance, parameters);
+            if (result is Task task)
+                task.ContinueWith(ActionOnException, TaskContinuationOptions.OnlyOnFaulted);
+        }
+        catch (TargetInvocationException e)
+        {
+            throw new CommandInvocationException(name, e);
+        }
 
         return;
 

--- a/src/PixiEditor/Models/ExceptionHandling/CrashedFileInfo.cs
+++ b/src/PixiEditor/Models/ExceptionHandling/CrashedFileInfo.cs
@@ -1,0 +1,16 @@
+﻿namespace PixiEditor.Models.ExceptionHandling;
+
+public class CrashedFileInfo
+{
+    public string ZipName { get; set; }
+    
+    public string OriginalPath { get; set; }
+    
+    public CrashedFileInfo() { }
+
+    public CrashedFileInfo(string zipName, string originalPath)
+    {
+        ZipName = zipName;
+        OriginalPath = originalPath;
+    }
+}

--- a/src/PixiEditor/Models/ExceptionHandling/CrashedSessionInfo.cs
+++ b/src/PixiEditor/Models/ExceptionHandling/CrashedSessionInfo.cs
@@ -1,0 +1,18 @@
+﻿namespace PixiEditor.Models.ExceptionHandling;
+
+public class CrashedSessionInfo
+{
+    public Guid? AnalyticsSessionId { get; set; }
+    
+    public ICollection<CrashedFileInfo>? OpenedDocuments { get; set; }
+
+    public CrashedSessionInfo()
+    {
+    }
+
+    public CrashedSessionInfo(Guid? analyticsSessionId, ICollection<CrashedFileInfo> openedDocuments)
+    {
+        AnalyticsSessionId = analyticsSessionId;
+        OpenedDocuments = openedDocuments;
+    }
+}


### PR DESCRIPTION
Send a Platform ID (e.g. "Windows", "Linux") and a full name "Microsoft Windows NT 10.0.19044.0" to the analytics API

And analytics sessions are now recovered after a crash