### PR TITLE
Added null check to MoveStructureMember_Change

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changes/Structure/MoveStructureMember_Change.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Structure/MoveStructureMember_Change.cs
@@ -136,7 +136,7 @@ internal class MoveStructureMember_Change : Change
 
         if (targetNode is FolderNode folder)
         {
-            folder.Content.Connection.Node.TraverseBackwards(contentNode =>
+            folder.Content.Connection?.Node.TraverseBackwards(contentNode =>
             {
                 if (contentNode is Node node)
                 {

--- a/src/PixiEditor.UpdateModule/UpdateDownloader.cs
+++ b/src/PixiEditor.UpdateModule/UpdateDownloader.cs
@@ -14,8 +14,8 @@ public static class UpdateDownloader
     public static async Task DownloadReleaseZip(ReleaseInfo release)
     {
         Asset? matchingAsset = GetMatchingAsset(release);
-        
-        if(matchingAsset == null)
+
+        if (matchingAsset == null)
         {
             throw new FileNotFoundException("No matching update for your system found.");
         }
@@ -36,7 +36,7 @@ public static class UpdateDownloader
     {
         Asset? matchingAsset = GetMatchingAsset(info, "application/x-msdownload");
 
-        if(matchingAsset == null)
+        if (matchingAsset == null)
         {
             throw new FileNotFoundException("No matching update for your system found.");
         }
@@ -63,9 +63,16 @@ public static class UpdateDownloader
 
     private static Asset? GetMatchingAsset(ReleaseInfo release, string assetType = "zip")
     {
+        if (release.TagName.StartsWith("1."))
+        {
+            string archOld = IntPtr.Size == 8 ? "x64" : "x86";
+            return release.Assets.FirstOrDefault(x => x.ContentType.Contains(assetType)
+                                                      && x.Name.Contains(archOld));
+        }
+
         string arch = "x64";
         string os = OperatingSystem.IsWindows() ? "win" : OperatingSystem.IsLinux() ? "linux" : "mac";
         return release.Assets.FirstOrDefault(x => x.ContentType.Contains(assetType)
-                                         && x.Name.Contains(arch) && x.Name.Contains(os));
+                                                  && x.Name.Contains(arch) && x.Name.Contains(os));
     }
 }


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

Fixes exception when folder has no content

 ## If possible, show examples of usage

## SELECT BELOW TO CONTINUE
- [x] I wrote tests for my changes (if possible)
- [x] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
