### PR TITLE
Fixed ToPaintable not having alpha

### DIFF
--- a/src/PixiEditor/Helpers/Extensions/ColorHelpers.cs
+++ b/src/PixiEditor/Helpers/Extensions/ColorHelpers.cs
@@ -41,7 +41,7 @@ internal static class ColorHelpers
     public static Paintable ToPaintable(this IBrush avaloniaBrush) => avaloniaBrush switch
     {
         ISolidColorBrush solidColorBrush => new BackendColor(solidColorBrush.Color.R, solidColorBrush.Color.G,
-            solidColorBrush.Color.B),
+            solidColorBrush.Color.B, solidColorBrush.Color.A),
         ILinearGradientBrush linearGradientBrush =>
             new LinearGradientPaintable(
                 new VecD(linearGradientBrush.StartPoint.Point.X, linearGradientBrush.StartPoint.Point.Y),


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

Fixed alpha not being taken into consideration when converting to Paintable

## SELECT BELOW TO CONTINUE
- [x] I wrote tests for my changes (if possible)
- [x] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
