### PR TITLE
Fixes/21.03

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changes/Drawing/LineBasedPen_UpdateableChange.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Drawing/LineBasedPen_UpdateableChange.cs
@@ -152,10 +152,14 @@ internal class LineBasedPen_UpdateableChange : UpdateableChange
         }
     }
 
-    private RadialGradientPaintable? ApplySoftnessGradient(VecD pos)
+    private Paintable? ApplySoftnessGradient(VecD pos)
     {
-        if (hardness >= 1) return null;
         srcPaint.Paintable?.Dispose();
+        if (hardness >= 1)
+        {
+            return new ColorPaintable(color);
+        }
+
         float radius = strokeWidth / 2f;
         radius = MathF.Max(1, radius);
         return new RadialGradientPaintable(pos, radius,

--- a/src/PixiEditor/Data/Configs/ToolSetsConfig.json
+++ b/src/PixiEditor/Data/Configs/ToolSetsConfig.json
@@ -125,7 +125,9 @@
           "AntiAliasing": true,
           "ForceLowDpiRendering": false
         }
-      }
+      },
+      "ColorPicker",
+      "Zoom"
     ]
   }
 ]

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/TransformSelectedExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/TransformSelectedExecutor.cs
@@ -453,7 +453,6 @@ internal class TransformSelectedExecutor : UpdateableChangeExecutor, ITransforma
 
         isInProgress = false;
         document.TransformHandler.PassthroughPointerPressed -= OnLeftMouseButtonDown;
-        DuplicateIfRequired();
     }
 
     private void DuplicateIfRequired()

--- a/src/PixiEditor/Views/Rendering/Scene.cs
+++ b/src/PixiEditor/Views/Rendering/Scene.cs
@@ -618,7 +618,7 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
 
     public void QueueNextFrame()
     {
-        if (initialized && !updateQueued && compositor != null)
+        if (initialized && !updateQueued && compositor != null && surface is { IsDisposed: false })
         {
             updateQueued = true;
             compositor.RequestCompositionUpdate(update);


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

- Fixed a bug that caused painting brush with hardness 100% to be always black.
- Fixed a bug that caused layer to duplicate twice when using ctrl
- Added Color Picker and Zoom to vector toolset

## SELECT BELOW TO CONTINUE
- [x] I wrote tests for my changes (if possible)
- [x] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
