### PR TITLE
Suggest document's folder when exporting

### DIFF
--- a/src/PixiEditor/Views/Dialogs/ExportFilePopup.axaml.cs
+++ b/src/PixiEditor/Views/Dialogs/ExportFilePopup.axaml.cs
@@ -413,8 +413,8 @@ internal partial class ExportFilePopup : PixiEditorPopup
         {
             Title = new LocalizedString("EXPORT_SAVE_TITLE"),
             SuggestedFileName = SuggestedName,
-            SuggestedStartLocation =
-                await GetTopLevel(this).StorageProvider.TryGetWellKnownFolderAsync(WellKnownFolder.Documents),
+            SuggestedStartLocation = string.IsNullOrEmpty(document.FullFilePath) ? await GetTopLevel(this).StorageProvider.TryGetWellKnownFolderAsync(WellKnownFolder.Documents) : await GetTopLevel(this).StorageProvider.TryGetFolderFromPathAsync(document.FullFilePath),
+                
             FileTypeChoices =
                 SupportedFilesHelper.BuildSaveFilter(SelectedExportIndex == 1
                     ? FileTypeDialogDataSet.SetKind.Video


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible
When exporting PixiEditor now suggests to use folder where your document (file) is.
https://forum.pixieditor.net/t/export-to-same-folder-where-pixi-file-is/123

 ## If possible, show examples of usage
Open any supported file with PixiEditor, then try to export it.

## SELECT BELOW TO CONTINUE
- [x] I wrote tests for my changes (if possible)
- [x] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
