### PR TITLE
Fixes/28.03.2025

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/EllipseVectorData.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/EllipseVectorData.cs
@@ -98,4 +98,34 @@ public class EllipseVectorData : ShapeVectorData, IReadOnlyEllipseData
 
         return path;
     }
+
+    protected bool Equals(EllipseVectorData other)
+    {
+        return base.Equals(other) && Radius.Equals(other.Radius) && Center.Equals(other.Center);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((EllipseVectorData)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(base.GetHashCode(), Radius, Center);
+    }
 }

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/LineVectorData.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/LineVectorData.cs
@@ -121,4 +121,33 @@ public class LineVectorData : ShapeVectorData, IReadOnlyLineData
         return path;
     }
 
+    protected bool Equals(LineVectorData other)
+    {
+        return base.Equals(other) && Start.Equals(other.Start) && End.Equals(other.End);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((LineVectorData)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(base.GetHashCode(), Start, End);
+    }
 }

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/PathVectorData.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/PathVectorData.cs
@@ -115,4 +115,34 @@ public class PathVectorData : ShapeVectorData, IReadOnlyPathData
 
         return newPath;
     }
+
+    protected bool Equals(PathVectorData other)
+    {
+        return base.Equals(other) && Path.Equals(other.Path) && StrokeLineCap == other.StrokeLineCap && StrokeLineJoin == other.StrokeLineJoin;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((PathVectorData)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(base.GetHashCode(), Path, (int)StrokeLineCap, (int)StrokeLineJoin);
+    }
 }

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/PointsVectorData.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/PointsVectorData.cs
@@ -92,4 +92,34 @@ public class PointsVectorData : ShapeVectorData
 
         return path;
     }
+
+    protected bool Equals(PointsVectorData other)
+    {
+        return base.Equals(other) && (Points.Equals(other.Points) || Points.SequenceEqual(other.Points));
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((PointsVectorData)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(base.GetHashCode(), Points);
+    }
 }

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/RectangleVectorData.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/RectangleVectorData.cs
@@ -106,4 +106,34 @@ public class RectangleVectorData : ShapeVectorData, IReadOnlyRectangleData
 
         return path;
     }
+
+    protected bool Equals(RectangleVectorData other)
+    {
+        return base.Equals(other) && Center.Equals(other.Center) && Size.Equals(other.Size);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((RectangleVectorData)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(base.GetHashCode(), Center, Size);
+    }
 }

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/ShapeVectorData.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/ShapeVectorData.cs
@@ -15,7 +15,6 @@ public abstract class ShapeVectorData : ICacheable, ICloneable, IReadOnlyShapeVe
     private float strokeWidth = 0;
 
     public Matrix3X3 TransformationMatrix { get; set; } = Matrix3X3.Identity;
-
     public Paintable Stroke { get; set; } = Colors.White;
     public Paintable FillPaintable { get; set; } = Colors.White;
 
@@ -78,8 +77,33 @@ public abstract class ShapeVectorData : ICacheable, ICloneable, IReadOnlyShapeVe
 
     public override int GetHashCode()
     {
-        return GetCacheHash();
+        return HashCode.Combine(TransformationMatrix, Stroke, FillPaintable, Fill);
     }
 
     public abstract VectorPath ToPath(bool transformed = false);
+
+    protected bool Equals(ShapeVectorData other)
+    {
+        return TransformationMatrix.Equals(other.TransformationMatrix) && Stroke.Equals(other.Stroke) && FillPaintable.Equals(other.FillPaintable) && Fill == other.Fill && StrokeWidth.Equals(other.StrokeWidth);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((ShapeVectorData)obj);
+    }
 }

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/TextVectorData.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/Data/TextVectorData.cs
@@ -12,6 +12,8 @@ namespace PixiEditor.ChangeableDocument.Changeables.Graph.Nodes.Shapes.Data;
 
 public class TextVectorData : ShapeVectorData, IReadOnlyTextData, IScalable
 {
+    private bool bold;
+    private bool italic;
     private string text;
     private Font font = Font.CreateDefault();
     private double? spacing = null;
@@ -52,6 +54,28 @@ public class TextVectorData : ShapeVectorData, IReadOnlyTextData, IScalable
             }
 
             lastBounds = richText.MeasureBounds(value);
+        }
+    }
+
+    public bool Bold
+    {
+        get => bold;
+        set
+        {
+            bold = value;
+            Font.Bold = value;
+            lastBounds = richText.MeasureBounds(Font);
+        }
+    }
+
+    public bool Italic
+    {
+        get => italic;
+        set
+        {
+            italic = value;
+            Font.Italic = value;
+            lastBounds = richText.MeasureBounds(Font);
         }
     }
 
@@ -235,6 +259,9 @@ public class TextVectorData : ShapeVectorData, IReadOnlyTextData, IScalable
         hash.Add(AntiAlias);
         hash.Add(MissingFontFamily);
         hash.Add(MissingFontText);
+        hash.Add(MaxWidth);
+        hash.Add(Bold);
+        hash.Add(Italic);
 
         return hash.ToHashCode();
     }
@@ -256,5 +283,36 @@ public class TextVectorData : ShapeVectorData, IReadOnlyTextData, IScalable
         TransformationMatrix = TransformationMatrix.PostConcat(Matrix3X3.CreateScale((float)multiplier.X, (float)multiplier.Y));
 
         lastBounds = richText.MeasureBounds(Font);
+    }
+
+    protected bool Equals(TextVectorData other)
+    {
+        return base.Equals(other) && Position.Equals(other.Position) && MaxWidth.Equals(other.MaxWidth) && AntiAlias == other.AntiAlias && Nullable.Equals(MissingFontFamily, other.MissingFontFamily) && MissingFontText == other.MissingFontText
+            && Text == other.Text && Font.Equals(other.Font) && Spacing.Equals(other.Spacing) && Path == other.Path && Bold == other.Bold && Italic == other.Italic;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((TextVectorData)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(base.GetHashCode(), Position, MaxWidth, AntiAlias, MissingFontFamily, MissingFontText, Font, HashCode.Combine(Text, Spacing, Path));
     }
 }

--- a/src/PixiEditor.ChangeableDocument/Changes/Vectors/SetShapeGeometry_UpdateableChange.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Vectors/SetShapeGeometry_UpdateableChange.cs
@@ -10,23 +10,29 @@ internal class SetShapeGeometry_UpdateableChange : InterruptableUpdateableChange
 {
     public Guid TargetId { get; set; }
     public ShapeVectorData Data { get; set; }
+    public VectorShapeChangeType ChangeType { get; set; }
 
     private ShapeVectorData? originalData;
 
     private AffectedArea lastAffectedArea;
 
     [GenerateUpdateableChangeActions]
-    public SetShapeGeometry_UpdateableChange(Guid targetId, ShapeVectorData data)
+    public SetShapeGeometry_UpdateableChange(Guid targetId, ShapeVectorData data, VectorShapeChangeType changeType)
     {
         TargetId = targetId;
         Data = data;
+        ChangeType = changeType;
     }
 
     public override bool InitializeAndValidate(Document target)
     {
         if (target.TryFindNode<VectorLayerNode>(TargetId, out var node))
         {
-            // TODO: Add is identical check
+            if (IsIdentical(node.ShapeData, Data))
+            {
+                return false;
+            }
+
             originalData = (ShapeVectorData?)node.ShapeData?.Clone();
             return true;
         }
@@ -45,7 +51,7 @@ internal class SetShapeGeometry_UpdateableChange : InterruptableUpdateableChange
         var node = target.FindNode<VectorLayerNode>(TargetId);
 
         node.ShapeData = Data;
-        
+
         RectD aabb = node.ShapeData.TransformedAABB.RoundOutwards();
         aabb = aabb with { Size = new VecD(Math.Max(1, aabb.Size.X), Math.Max(1, aabb.Size.Y)) };
 
@@ -99,13 +105,46 @@ internal class SetShapeGeometry_UpdateableChange : InterruptableUpdateableChange
         return new VectorShape_ChangeInfo(node.Id, affected);
     }
 
+    private bool IsIdentical(ShapeVectorData? a, ShapeVectorData? b)
+    {
+        if (a is null && b is null)
+        {
+            return true;
+        }
+
+        if (a is null || b is null)
+        {
+            return false;
+        }
+
+        if (a.GetType() != b.GetType())
+        {
+            return false;
+        }
+
+        return a.Equals(b);
+    }
+
     public override bool IsMergeableWith(Change other)
     {
         if (other is SetShapeGeometry_UpdateableChange change)
         {
-            return change.TargetId == TargetId && change.Data is not TextVectorData; // text should not be merged into one change
+            return change.TargetId == TargetId &&
+                   !ChangeType.HasFlag(VectorShapeChangeType.GeometryData) && ChangeType.HasFlag(change.ChangeType) &&
+                   change.Data is not TextVectorData; // text should not be merged into one change
         }
 
         return false;
     }
+}
+
+[Flags]
+public enum VectorShapeChangeType
+{
+    GeometryData = 1,
+    Stroke = 2,
+    Fill = 4,
+    TransformationMatrix = 8,
+    OtherVisuals = 16,
+    All = ~0
 }

--- a/src/PixiEditor/Models/DocumentModels/ChangeExecutionController.cs
+++ b/src/PixiEditor/Models/DocumentModels/ChangeExecutionController.cs
@@ -44,7 +44,7 @@ internal class ChangeExecutionController
 
     public bool IsChangeOfTypeActive<T>() where T : IExecutorFeature
     {
-        return currentSession is T sessionT && sessionT.IsFeatureEnabled(sessionT);
+        return currentSession is T sessionT && sessionT.IsFeatureEnabled<T>();
     }
 
     public ExecutorType GetCurrentExecutorType()

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/DrawableShapeToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/DrawableShapeToolExecutor.cs
@@ -74,7 +74,7 @@ internal abstract class DrawableShapeToolExecutor<T> : SimpleShapeToolExecutor w
 
             lastRect = new RectD(startDrawingPos, VecD.Zero);
 
-            document!.TransformHandler.ShowTransform(TransformMode, false, new ShapeCorners((RectD)lastRect.Inflate(1)),
+            document!.TransformHandler.ShowTransform(TransformMode, false, new ShapeCorners(lastRect),
                 false, UseGlobalUndo ? AddToUndo : null);
             document.TransformHandler.ShowHandles = false;
             document.TransformHandler.IsSizeBoxEnabled = true;
@@ -362,6 +362,23 @@ internal abstract class DrawableShapeToolExecutor<T> : SimpleShapeToolExecutor w
 
                 base.OnLeftMouseButtonUp(argsPositionOnCanvas);
                 onEnded?.Invoke(this);
+
+                if (lastRect.Size == VecD.Zero)
+                {
+                    var member = document!.StructureHelper.Find(memberId);
+                    if (member is not null)
+                    {
+                        document.Operations.DeleteStructureMember(memberId);
+                        document.TransformHandler.HideTransform();
+                    }
+                }
+
+                var layersUnderCursor = QueryLayers<ILayerHandler>(argsPositionOnCanvas);
+                if (layersUnderCursor.Any())
+                {
+                    document.Operations.SetSelectedMember(layersUnderCursor.First().Id);
+                }
+
                 return;
             }
         }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/DrawableShapeToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/DrawableShapeToolExecutor.cs
@@ -55,6 +55,8 @@ internal abstract class DrawableShapeToolExecutor<T> : SimpleShapeToolExecutor w
     public override bool CanUndo => !UseGlobalUndo && document.TransformHandler.HasUndo;
     public override bool CanRedo => !UseGlobalUndo && document.TransformHandler.HasRedo;
 
+    protected virtual bool ApplyEachSettingsChange => false;
+
     public override ExecutionState Start()
     {
         if (base.Start() == ExecutionState.Error)
@@ -372,9 +374,15 @@ internal abstract class DrawableShapeToolExecutor<T> : SimpleShapeToolExecutor w
 
         if (CanEditShape(layer))
         {
-            internals!.ActionAccumulator.AddFinishedActions(EndDrawAction(), SettingsChangedAction(name, value),
-                EndDrawAction());
-            // TODO add to undo
+            if (ApplyEachSettingsChange)
+            {
+                internals!.ActionAccumulator.AddFinishedActions(EndDrawAction(), SettingsChangedAction(name, value),
+                    EndDrawAction());
+            }
+            else
+            {
+                internals!.ActionAccumulator.AddActions(SettingsChangedAction(name, value));
+            }
         }
     }
 

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/Features/IExecutorFeature.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/Features/IExecutorFeature.cs
@@ -2,5 +2,5 @@
 
 public interface IExecutorFeature
 {
-    public bool IsFeatureEnabled(IExecutorFeature feature);
+    public bool IsFeatureEnabled<T>();
 }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/LineExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/LineExecutor.cs
@@ -30,7 +30,7 @@ internal abstract class LineExecutor<T> : SimpleShapeToolExecutor where T : ILin
     protected bool drawOnMask;
 
     protected VecD curPos;
-    private bool startedDrawing = false;
+    protected bool startedDrawing = false;
     private T? toolViewModel;
     private IColorsHandler? colorsVM;
     protected IShapeToolbar? toolbar;

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/LineExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/LineExecutor.cs
@@ -112,7 +112,7 @@ internal abstract class LineExecutor<T> : SimpleShapeToolExecutor where T : ILin
     protected abstract bool InitShapeData(IReadOnlyLineData? data);
     protected abstract IAction DrawLine(VecD pos);
     protected abstract IAction TransformOverlayMoved(VecD start, VecD end);
-    protected abstract IAction[] SettingsChange();
+    protected abstract IAction[] SettingsChange(string name, object value);
     protected abstract IAction EndDraw();
 
     protected override void PrecisePositionChangeDrawingMode(VecD pos)
@@ -210,7 +210,7 @@ internal abstract class LineExecutor<T> : SimpleShapeToolExecutor where T : ILin
 
         ignoreNextColorChange = ActiveMode == ShapeToolMode.Drawing;
         toolbar!.StrokeBrush = new SolidColorBrush(color.ToColor());
-        var colorChangedAction = SettingsChange();
+        var colorChangedAction = SettingsChange(nameof(IShapeToolbar.StrokeBrush), color);
         internals!.ActionAccumulator.AddActions(colorChangedAction);
     }
 
@@ -225,7 +225,7 @@ internal abstract class LineExecutor<T> : SimpleShapeToolExecutor where T : ILin
 
     public override void OnSettingsChanged(string name, object value)
     {
-        var colorChangedActions = SettingsChange();
+        var colorChangedActions = SettingsChange(name, value);
         if (ActiveMode == ShapeToolMode.Transform)
         {
             internals!.ActionAccumulator.AddFinishedActions(colorChangedActions);

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/PasteImageExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/PasteImageExecutor.cs
@@ -90,12 +90,13 @@ internal class PasteImageExecutor : UpdateableChangeExecutor, ITransformableExec
         internals!.ActionAccumulator.AddActions(new EndPasteImage_Action());
     }
 
-    public bool IsFeatureEnabled(IExecutorFeature feature)
+    public bool IsFeatureEnabled<T>()
     {
-        if (feature is ITransformableExecutor)
+        Type featureType = typeof(T);
+        if (featureType == typeof(ITransformableExecutor))
             return IsTransforming;
         
-        if (feature is IMidChangeUndoableExecutor)
+        if (featureType == typeof(IMidChangeUndoableExecutor))
             return true;
 
         return false;

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/RasterEllipseToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/RasterEllipseToolExecutor.cs
@@ -32,7 +32,7 @@ internal class RasterEllipseToolExecutor : DrawableShapeToolExecutor<IRasterElli
     protected override bool UseGlobalUndo => false;
     protected override bool ShowApplyButton => true;
     protected override void DrawShape(VecD currentPos, double rotationRad, bool firstDraw) => DrawEllipseOrCircle(currentPos, rotationRad, firstDraw);
-    protected override IAction SettingsChangedAction()
+    protected override IAction SettingsChangedAction(string name, object value)
     {
         return new DrawRasterEllipse_Action(memberId, (RectI)lastRect, lastRadians, StrokePaintable, FillPaintable, (float)StrokeWidth, toolbar.AntiAliasing, drawOnMask, document!.AnimationHandler.ActiveFrameBindable);
     }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/RasterLineToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/RasterLineToolExecutor.cs
@@ -33,7 +33,7 @@ internal class RasterLineToolExecutor : LineExecutor<ILineToolHandler>
             (float)StrokeWidth, StrokePaintable, StrokeCap.Butt, toolbar.AntiAliasing, drawOnMask, document!.AnimationHandler.ActiveFrameBindable);
     }
 
-    protected override IAction[] SettingsChange()
+    protected override IAction[] SettingsChange(string name, object value)
     {
         VecD dir = GetSignedDirection(startDrawingPos, curPos);
         VecD oppositeDir = new VecD(-dir.X, -dir.Y);

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/RasterRectangleToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/RasterRectangleToolExecutor.cs
@@ -41,7 +41,7 @@ internal class RasterRectangleToolExecutor : DrawableShapeToolExecutor<IRasterRe
     protected override void DrawShape(VecD currentPos, double rotationRad, bool first) =>
         DrawRectangle(currentPos, rotationRad, first);
 
-    protected override IAction SettingsChangedAction()
+    protected override IAction SettingsChangedAction(string name, object value)
     {
         lastData = new ShapeData(lastData.Center, lastData.Size, lastRadians, (float)StrokeWidth, StrokePaintable, FillPaintable)
         {

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/SimpleShapeToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/SimpleShapeToolExecutor.cs
@@ -37,6 +37,9 @@ internal abstract class SimpleShapeToolExecutor : UpdateableChangeExecutor,
         get => activeMode;
         set
         {
+            if (activeMode == value)
+                return;
+
             StopMode(activeMode);
             activeMode = value;
             StartMode(activeMode);
@@ -249,19 +252,20 @@ internal abstract class SimpleShapeToolExecutor : UpdateableChangeExecutor,
     public abstract bool CanUndo { get; }
     public abstract bool CanRedo { get; }
 
-    public virtual bool IsFeatureEnabled(IExecutorFeature feature)
+    public virtual bool IsFeatureEnabled<T>()
     {
-        if (feature is ITransformableExecutor)
+        Type t = typeof(T);
+        if (t == typeof(ITransformableExecutor))
         {
             return IsTransforming;
         }
 
-        if (feature is IMidChangeUndoableExecutor)
+        if (t == typeof(IMidChangeUndoableExecutor))
         {
             return ActiveMode == ShapeToolMode.Transform;
         }
 
-        if (feature is IDelayedColorSwapFeature)
+        if (t == typeof(IDelayedColorSwapFeature))
         {
             return true;
         }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/TransformReferenceLayerExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/TransformReferenceLayerExecutor.cs
@@ -50,8 +50,8 @@ internal class TransformReferenceLayerExecutor : UpdateableChangeExecutor, ITran
         document.ReferenceLayerHandler.IsTransforming = false;
     }
 
-    public bool IsFeatureEnabled(IExecutorFeature feature)
+    public bool IsFeatureEnabled<T>()
     {
-        return feature is ITransformableExecutor;
+        return typeof(T) == typeof(ITransformableExecutor);
     }
 }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/TransformSelectedExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/TransformSelectedExecutor.cs
@@ -13,6 +13,7 @@ using PixiEditor.Models.Controllers.InputDevice;
 using PixiEditor.Models.DocumentPassthroughActions;
 using PixiEditor.ViewModels;
 using PixiEditor.ViewModels.Document.Nodes;
+using Type = System.Type;
 
 namespace PixiEditor.Models.DocumentModels.UpdateableChangeExecutors;
 #nullable enable
@@ -508,9 +509,11 @@ internal class TransformSelectedExecutor : UpdateableChangeExecutor, ITransforma
         }
     }
 
-    public bool IsFeatureEnabled(IExecutorFeature feature)
+    public bool IsFeatureEnabled<T>()
     {
-        return feature is ITransformableExecutor && IsTransforming || feature is IMidChangeUndoableExecutor ||
-               feature is ITransformStoppedEvent || feature is ITransformDraggedEvent;
+        Type feature = typeof(T);
+        return feature == typeof(ITransformableExecutor) && IsTransforming ||
+               feature == typeof(IMidChangeUndoableExecutor) ||
+               feature == typeof(ITransformStoppedEvent) || feature == typeof(ITransformDraggedEvent);
     }
 }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorEllipseToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorEllipseToolExecutor.cs
@@ -29,6 +29,7 @@ internal class VectorEllipseToolExecutor : DrawableShapeToolExecutor<IVectorElli
     protected override bool AlignToPixels => false;
     protected override bool DeleteLayerOnNoDraw => true;
     protected override bool SelectLayerOnTap => true;
+    protected override bool ApplyEachSettingsChange => true;
 
     protected override Predicate<ILayerHandler> CanSelectLayer => x => x is IVectorLayerHandler vec
                                                                        && vec.GetShapeData(vec.Document.AnimationHandler

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorEllipseToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorEllipseToolExecutor.cs
@@ -125,9 +125,9 @@ internal class VectorEllipseToolExecutor : DrawableShapeToolExecutor<IVectorElli
         return new EndSetShapeGeometry_Action();
     }
 
-    public override bool IsFeatureEnabled(IExecutorFeature feature)
+    public override bool IsFeatureEnabled<T>()
     {
-        if(feature is IMidChangeUndoableExecutor) return false;
-        return base.IsFeatureEnabled(feature);
+        if(typeof(T) == typeof(IMidChangeUndoableExecutor)) return false;
+        return base.IsFeatureEnabled<T>();
     }
 }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorEllipseToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorEllipseToolExecutor.cs
@@ -8,6 +8,7 @@ using PixiEditor.Models.Handlers.Tools;
 using PixiEditor.Models.Tools;
 using Drawie.Numerics;
 using PixiEditor.ChangeableDocument.Changeables.Graph.Interfaces;
+using PixiEditor.ChangeableDocument.Changeables.Graph.Interfaces.Shapes;
 using PixiEditor.Models.DocumentModels.UpdateableChangeExecutors.Features;
 using PixiEditor.Models.Handlers;
 
@@ -24,6 +25,12 @@ internal class VectorEllipseToolExecutor : DrawableShapeToolExecutor<IVectorElli
     private Matrix3X3 lastMatrix = Matrix3X3.Identity;
 
     protected override bool AlignToPixels => false;
+    protected override bool DeleteLayerOnNoDraw => true;
+    protected override bool SelectLayerOnTap => true;
+
+    protected override Predicate<ILayerHandler> CanSelectLayer => x => x is IVectorLayerHandler vec
+                                                                       && vec.GetShapeData(vec.Document.AnimationHandler
+                                                                           .ActiveFrameTime) is IReadOnlyEllipseData;
 
     protected override bool InitShapeData(IReadOnlyShapeVectorData data)
     {
@@ -127,7 +134,7 @@ internal class VectorEllipseToolExecutor : DrawableShapeToolExecutor<IVectorElli
 
     public override bool IsFeatureEnabled<T>()
     {
-        if(typeof(T) == typeof(IMidChangeUndoableExecutor)) return false;
+        if (typeof(T) == typeof(IMidChangeUndoableExecutor)) return false;
         return base.IsFeatureEnabled<T>();
     }
 }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorLineToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorLineToolExecutor.cs
@@ -60,10 +60,11 @@ internal class VectorLineToolExecutor : LineExecutor<IVectorLineToolHandler>
         return new EndSetShapeGeometry_Action();
     }
 
-    public override bool IsFeatureEnabled(IExecutorFeature feature)
+    public override bool IsFeatureEnabled<T>()
     {
-        if(feature is IMidChangeUndoableExecutor) return false;
+        Type feature = typeof(T);
+        if(feature == typeof(IMidChangeUndoableExecutor)) return false;
         
-        return base.IsFeatureEnabled(feature);
+        return base.IsFeatureEnabled<T>();
     }
 }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorLineToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorLineToolExecutor.cs
@@ -6,10 +6,11 @@ using PixiEditor.ChangeableDocument.Changeables.Graph.Nodes.Shapes.Data;
 using PixiEditor.Models.Handlers.Tools;
 using Drawie.Numerics;
 using PixiEditor.Models.DocumentModels.UpdateableChangeExecutors.Features;
+using PixiEditor.Models.Handlers;
 
 namespace PixiEditor.Models.DocumentModels.UpdateableChangeExecutors;
 
-internal class VectorLineToolExecutor : LineExecutor<IVectorLineToolHandler> 
+internal class VectorLineToolExecutor : LineExecutor<IVectorLineToolHandler>
 {
     private VecD startPoint;
     private VecD endPoint;
@@ -33,7 +34,7 @@ internal class VectorLineToolExecutor : LineExecutor<IVectorLineToolHandler>
     protected override IAction DrawLine(VecD pos)
     {
         LineVectorData data = ConstructLineData(startDrawingPos, pos);
-        
+
         startPoint = startDrawingPos;
         endPoint = pos;
 
@@ -43,11 +44,34 @@ internal class VectorLineToolExecutor : LineExecutor<IVectorLineToolHandler>
     protected override IAction TransformOverlayMoved(VecD start, VecD end)
     {
         var data = ConstructLineData(start, end);
-        
+
         startPoint = start;
         endPoint = end;
 
         return new SetShapeGeometry_Action(memberId, data);
+    }
+
+    public override void OnLeftMouseButtonUp(VecD argsPositionOnCanvas)
+    {
+        base.OnLeftMouseButtonUp(argsPositionOnCanvas);
+
+        if (!startedDrawing)
+        {
+            var member = document!.StructureHelper.Find(memberId);
+            if (member is not null)
+            {
+                document.Operations.DeleteStructureMember(memberId);
+                document.TransformHandler.HideTransform();
+            }
+        }
+
+        var layersUnderCursor = QueryLayers<IVectorLayerHandler>(argsPositionOnCanvas);
+        var firstValidLayer = layersUnderCursor.FirstOrDefault(x =>
+            x.GetShapeData(document.AnimationHandler.ActiveFrameTime) is IReadOnlyLineData);
+        if (firstValidLayer != null)
+        {
+            document.Operations.SetSelectedMember(firstValidLayer.Id);
+        }
     }
 
     protected override IAction[] SettingsChange()
@@ -63,8 +87,8 @@ internal class VectorLineToolExecutor : LineExecutor<IVectorLineToolHandler>
     public override bool IsFeatureEnabled<T>()
     {
         Type feature = typeof(T);
-        if(feature == typeof(IMidChangeUndoableExecutor)) return false;
-        
+        if (feature == typeof(IMidChangeUndoableExecutor)) return false;
+
         return base.IsFeatureEnabled<T>();
     }
 }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorPathToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorPathToolExecutor.cs
@@ -98,9 +98,9 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
                 }
 
                 //below forces undo before starting new path
-               // internals.ActionAccumulator.AddFinishedActions(new EndSetShapeGeometry_Action());
+                // internals.ActionAccumulator.AddFinishedActions(new EndSetShapeGeometry_Action());
 
-               // internals.ActionAccumulator.AddActions(new SetShapeGeometry_Action(member.Id, ConstructShapeData(startingPath)));
+                // internals.ActionAccumulator.AddActions(new SetShapeGeometry_Action(member.Id, ConstructShapeData(startingPath)));
             }
         }
         else
@@ -150,11 +150,11 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
             }
         }
     }
-    
+
     private bool WholePathClosed()
     {
         EditableVectorPath editablePath = new EditableVectorPath(startingPath);
-        
+
         return editablePath.SubShapes.Count > 0 && editablePath.SubShapes.All(x => x.IsClosed);
     }
 
@@ -176,7 +176,9 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
     {
         if (document.PathOverlayHandler.IsActive)
         {
-            internals.ActionAccumulator.AddFinishedActions(new SetShapeGeometry_Action(member.Id, ConstructShapeData(startingPath)), new EndSetShapeGeometry_Action());
+            internals.ActionAccumulator.AddFinishedActions(
+                new SetShapeGeometry_Action(member.Id, ConstructShapeData(startingPath)),
+                new EndSetShapeGeometry_Action());
         }
     }
 
@@ -198,7 +200,7 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
 
     private PathVectorData ConstructShapeData(VectorPath? path)
     {
-        if(path is null)
+        if (path is null)
         {
             return new PathVectorData(new VectorPath() { FillType = (PathFillType)vectorPathToolHandler.FillMode })
             {
@@ -210,7 +212,7 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
                 StrokeLineJoin = vectorPathToolHandler.StrokeLineJoin
             };
         }
-        
+
         return new PathVectorData(new VectorPath(path) { FillType = (PathFillType)vectorPathToolHandler.FillMode })
         {
             StrokeWidth = (float)toolbar.ToolSize,
@@ -227,19 +229,17 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
         if (document.PathOverlayHandler.IsActive)
         {
             startingPath = path;
-            internals.ActionAccumulator.AddActions(new SetShapeGeometry_Action(member.Id, ConstructShapeData(startingPath)));
+            internals.ActionAccumulator.AddActions(new SetShapeGeometry_Action(member.Id,
+                ConstructShapeData(startingPath)));
         }
     }
 
-    public bool IsFeatureEnabled(IExecutorFeature feature)
+    public bool IsFeatureEnabled<T>()
     {
-        return feature switch
-        {
-            IPathExecutorFeature _ => true,
-            IMidChangeUndoableExecutor _ => true,
-            ITransformableExecutor _ => true,
-            _ => false
-        };
+        Type feature = typeof(T);
+        return feature == typeof(IMidChangeUndoableExecutor)
+               || feature == typeof(ITransformableExecutor)
+               || feature == typeof(IPathExecutorFeature);
     }
 
     protected void HighlightSnapping(string? snapX, string? snapY)
@@ -259,7 +259,7 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
 
         return shapeData is not IReadOnlyPathData pathData || pathData.Path.IsClosed;
     }
-    
+
     private void ApplySettings(PathVectorData pathData)
     {
         toolbar.ToolSize = pathData.StrokeWidth;
@@ -267,8 +267,11 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
         toolbar.ToolSize = pathData.StrokeWidth;
         toolbar.Fill = pathData.Fill;
         toolbar.FillBrush = pathData.FillPaintable.ToBrush();
-        toolbar.GetSetting<EnumSettingViewModel<VectorPathFillType>>(nameof(VectorPathToolViewModel.FillMode)).Value = (VectorPathFillType)pathData.Path.FillType;
-        toolbar.GetSetting<EnumSettingViewModel<StrokeCap>>(nameof(VectorPathToolViewModel.StrokeLineCap)).Value = pathData.StrokeLineCap;
-        toolbar.GetSetting<EnumSettingViewModel<StrokeJoin>>(nameof(VectorPathToolViewModel.StrokeLineJoin)).Value = pathData.StrokeLineJoin;
+        toolbar.GetSetting<EnumSettingViewModel<VectorPathFillType>>(nameof(VectorPathToolViewModel.FillMode)).Value =
+            (VectorPathFillType)pathData.Path.FillType;
+        toolbar.GetSetting<EnumSettingViewModel<StrokeCap>>(nameof(VectorPathToolViewModel.StrokeLineCap)).Value =
+            pathData.StrokeLineCap;
+        toolbar.GetSetting<EnumSettingViewModel<StrokeJoin>>(nameof(VectorPathToolViewModel.StrokeLineJoin)).Value =
+            pathData.StrokeLineJoin;
     }
 }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorPathToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorPathToolExecutor.cs
@@ -12,6 +12,7 @@ using PixiEditor.ChangeableDocument.Actions.Generated;
 using PixiEditor.ChangeableDocument.Changeables.Animations;
 using PixiEditor.ChangeableDocument.Changeables.Graph.Interfaces.Shapes;
 using PixiEditor.ChangeableDocument.Changeables.Graph.Nodes;
+using PixiEditor.ChangeableDocument.Changes.Vectors;
 using PixiEditor.Helpers.Extensions;
 using PixiEditor.Models.Controllers.InputDevice;
 using PixiEditor.Models.DocumentModels.Public;
@@ -176,8 +177,17 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
     {
         if (document.PathOverlayHandler.IsActive)
         {
+            VectorShapeChangeType changeType = name switch
+            {
+                nameof(IFillableShapeToolbar.Fill) => VectorShapeChangeType.Fill,
+                nameof(IShapeToolbar.StrokeBrush) => VectorShapeChangeType.Stroke,
+                nameof(IShapeToolbar.ToolSize) => VectorShapeChangeType.Stroke,
+                nameof(IShapeToolbar.AntiAliasing) => VectorShapeChangeType.OtherVisuals,
+                _ => VectorShapeChangeType.All
+            };
+
             internals.ActionAccumulator.AddFinishedActions(
-                new SetShapeGeometry_Action(member.Id, ConstructShapeData(startingPath)),
+                new SetShapeGeometry_Action(member.Id, ConstructShapeData(startingPath), changeType),
                 new EndSetShapeGeometry_Action());
         }
     }
@@ -195,7 +205,7 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
     private void AddToUndo(VectorPath path)
     {
         internals.ActionAccumulator.AddFinishedActions(new EndSetShapeGeometry_Action(),
-            new SetShapeGeometry_Action(member.Id, ConstructShapeData(path)), new EndSetShapeGeometry_Action());
+            new SetShapeGeometry_Action(member.Id, ConstructShapeData(path), VectorShapeChangeType.GeometryData), new EndSetShapeGeometry_Action());
     }
 
     private PathVectorData ConstructShapeData(VectorPath? path)
@@ -230,7 +240,7 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
         {
             startingPath = path;
             internals.ActionAccumulator.AddActions(new SetShapeGeometry_Action(member.Id,
-                ConstructShapeData(startingPath)));
+                ConstructShapeData(startingPath), VectorShapeChangeType.GeometryData));
         }
     }
 

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorRectangleToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorRectangleToolExecutor.cs
@@ -8,6 +8,7 @@ using PixiEditor.Models.Handlers.Tools;
 using PixiEditor.Models.Tools;
 using Drawie.Numerics;
 using PixiEditor.ChangeableDocument.Changeables.Graph.Interfaces;
+using PixiEditor.ChangeableDocument.Changeables.Graph.Interfaces.Shapes;
 using PixiEditor.Models.DocumentModels.UpdateableChangeExecutors.Features;
 using PixiEditor.Models.Handlers;
 
@@ -24,6 +25,13 @@ internal class VectorRectangleToolExecutor : DrawableShapeToolExecutor<IVectorRe
     private Matrix3X3 lastMatrix = Matrix3X3.Identity;
 
     protected override bool AlignToPixels => false;
+
+    protected override bool DeleteLayerOnNoDraw => true;
+    protected override bool SelectLayerOnTap => true;
+
+    protected override Predicate<ILayerHandler> CanSelectLayer => x => x is IVectorLayerHandler vec
+                                                                       && vec.GetShapeData(vec.Document.AnimationHandler
+                                                                           .ActiveFrameTime) is IReadOnlyRectangleData;
 
     protected override bool InitShapeData(IReadOnlyShapeVectorData data)
     {

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorRectangleToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorRectangleToolExecutor.cs
@@ -132,9 +132,9 @@ internal class VectorRectangleToolExecutor : DrawableShapeToolExecutor<IVectorRe
         return new EndSetShapeGeometry_Action();
     }
 
-    public override bool IsFeatureEnabled(IExecutorFeature feature)
+    public override bool IsFeatureEnabled<T>()
     {
-        if (feature is IMidChangeUndoableExecutor) return false;
-        return base.IsFeatureEnabled(feature);
+        if (typeof(T) == typeof(IMidChangeUndoableExecutor)) return false;
+        return base.IsFeatureEnabled<T>();
     }
 }

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorRectangleToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorRectangleToolExecutor.cs
@@ -30,6 +30,7 @@ internal class VectorRectangleToolExecutor : DrawableShapeToolExecutor<IVectorRe
 
     protected override bool DeleteLayerOnNoDraw => true;
     protected override bool SelectLayerOnTap => true;
+    protected override bool ApplyEachSettingsChange => true;
 
     protected override Predicate<ILayerHandler> CanSelectLayer => x => x is IVectorLayerHandler vec
                                                                        && vec.GetShapeData(vec.Document.AnimationHandler
@@ -82,7 +83,8 @@ internal class VectorRectangleToolExecutor : DrawableShapeToolExecutor<IVectorRe
 
         lastRect = rect;
 
-        internals!.ActionAccumulator.AddActions(new SetShapeGeometry_Action(memberId, data, VectorShapeChangeType.GeometryData));
+        internals!.ActionAccumulator.AddActions(new SetShapeGeometry_Action(memberId, data,
+            VectorShapeChangeType.GeometryData));
     }
 
     protected override IAction SettingsChangedAction(string name, object value)

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorTextToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorTextToolExecutor.cs
@@ -273,8 +273,8 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
         };
     }
 
-    bool IExecutorFeature.IsFeatureEnabled(IExecutorFeature feature)
+    bool IExecutorFeature.IsFeatureEnabled<T>()
     {
-        return feature is ITextOverlayEvents || feature is IQuickToolSwitchable;
+        return typeof(T) == typeof(ITextOverlayEvents) || typeof(T) == typeof(IQuickToolSwitchable);
     }
 }

--- a/src/PixiEditor/Views/Overlays/TextOverlay/TextOverlay.cs
+++ b/src/PixiEditor/Views/Overlays/TextOverlay/TextOverlay.cs
@@ -639,7 +639,7 @@ internal class TextOverlay : Overlay
 
     private void UpdateGlyphs()
     {
-        if (Font == null) return;
+        if (Font == null || Font.IsDisposed) return;
 
         richText = new(Text);
         richText.Spacing = Spacing;


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

#753 
- Improved undo for vector shapes (and in general for automatic actions)
- Text tool now inherits primarty color for fill on use
- Fixed color swapping on right click for shapes

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
