### PR TITLE
Fixes/11.04.2025

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/ImageLayerNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/ImageLayerNode.cs
@@ -267,7 +267,7 @@ public class ImageLayerNode : LayerNode, IReadOnlyImageNode
     public override void Dispose()
     {
         base.Dispose();
-        fullResrenderedSurface.Dispose();
+        fullResrenderedSurface?.Dispose();
     }
 
     IReadOnlyChunkyImage IReadOnlyImageNode.GetLayerImageAtFrame(int frame) => GetLayerImageAtFrame(frame);

--- a/src/PixiEditor/Data/ShortcutActionMaps/AsepriteShortcutMap.json
+++ b/src/PixiEditor/Data/ShortcutActionMaps/AsepriteShortcutMap.json
@@ -1,598 +1,675 @@
 ﻿{
-    "Cut": {
-      "Command": "PixiEditor.Clipboard.Cut",
-      "DefaultShortcut": {
-        "key": "X",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "Paste": {
-      "Command": "PixiEditor.Clipboard.Paste",
-      "DefaultShortcut": {
-        "key": "V",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Clipboard.PasteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "Copy": {
-      "Command": "PixiEditor.Clipboard.Copy",
-      "DefaultShortcut": {
-        "key": "C",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.OpenPaletteBrowser",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "LoadPalette": {
-      "Command": "PixiEditor.Colors.ImportPalette",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.SelectFirstPaletteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.SelectSecondPaletteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.SelectThirdPaletteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.SelectFourthPaletteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.SelectFifthPaletteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.SelectSixthPaletteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.SelectSeventhPaletteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.SelectEighthPaletteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.SelectNinthPaletteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.SelectTenthPaletteColor",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "SwitchColors": {
-      "Command": "PixiEditor.Colors.Swap",
-      "DefaultShortcut": {
-        "key": "X",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Colors.RemoveSwatch",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "NewFile": {
-      "Command": "PixiEditor.File.New",
-      "DefaultShortcut": {
-        "key": "N",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "OpenFile": {
-      "Command": "PixiEditor.File.Open",
-      "DefaultShortcut": {
-        "key": "O",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "Recent": {
-      "Command": "PixiEditor.File.OpenRecent",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "SaveFile": {
-      "Command": "PixiEditor.File.Save",
-      "DefaultShortcut": {
-        "key": "S",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "SaveFileAs": {
-      "Command": "PixiEditor.File.SaveAsNew",
-      "DefaultShortcut": {
-        "key": "S",
-        "modifiers": ["Ctrl", "Shift"]
-      },
-      "Parameters": []
-    },
-    "SaveFileCopyAs": {
-      "Command": "PixiEditor.File.Export",
-      "DefaultShortcut": {
-        "key": "S",
-        "modifiers": ["Ctrl", "Alt", "Shift"]
-      },
-      "Parameters": []
-    },
-    "RemoveLayer": {
-      "Command": "PixiEditor.Layer.DeleteAllSelected",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "NewLayer.group=true": {
-      "Command": "PixiEditor.Layer.NewFolder",
-      "DefaultShortcut": {
-        "key": "N",
-        "modifiers": ["Alt", "Shift"]
-      },
-      "Parameters": []
-    },
-    "NewLayer": {
-      "Command": "PixiEditor.Layer.NewLayer",
-      "DefaultShortcut": {
-        "key": "N",
-        "modifiers": ["Shift"]
-      },
-      "Parameters": []
-    },
-    "SetInkType.type=lock-alpha": {
-      "Command": "PixiEditor.Layer.ToggleLockTransparency",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "DuplicateLayer": {
-      "Command": "PixiEditor.Layer.DuplicateSelectedMember",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Layer.CreateMask",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Layer.DeleteMask",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Layer.MoveSelectedMemberUpwards",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Layer.MoveSelectedMemberDownwards",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Layer.MergeSelected",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Layer.MergeWithAbove",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "MergeDownLayer": {
-      "Command": "PixiEditor.Layer.MergeWithBelow",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "Launch.path=/docs/.type=url": {
-      "Command": "PixiEditor.Links.OpenDocumentation",
-      "DefaultShortcut": {
-        "key": "B",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "MaskAll": {
-      "Command": "PixiEditor.Selection.SelectAll",
-      "DefaultShortcut": {
-        "key": "A",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "DeselectMask": {
-      "Command": "PixiEditor.Selection.Clear",
-      "DefaultShortcut": {
-        "key": "D",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Selection.TransformArea",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Stylus.TogglePenMode",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "ChangeBrush.change=increment-size": {
-      "Command": "PixiEditor.Tools.IncreaseSize",
-      "DefaultShortcut": {
-        "key": "+",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "ChangeBrush.change=decrement-size": {
-      "Command": "PixiEditor.Tools.DecreaseSize",
-      "DefaultShortcut": {
-        "key": "-",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "Redo": {
-      "Command": "PixiEditor.Undo.Redo",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "Undo": {
-      "Command": "PixiEditor.Undo.Undo",
-      "DefaultShortcut": {
-        "key": "Z",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "ShowGrid": {
-      "Command": "PixiEditor.View.ToggleGrid",
-      "DefaultShortcut": {
-        "key": "'",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "Zoom.action=in": {
-      "Command": "PixiEditor.View.ZoomIn",
-      "DefaultShortcut": {
-        "key": "+",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "Zoom.action=out": {
-      "Command": "PixiEditor.View.Zoomout",
-      "DefaultShortcut": {
-        "key": "-",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Window.CreateNewViewport",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "Options": {
-      "Command": "PixiEditor.Window.OpenSettingsWindow",
-      "DefaultShortcut": {
-        "key": "K",
-        "modifiers": ["Ctrl"]
-      },
-      "Parameters": []
-    },
-    "Home": {
-      "Command": "PixiEditor.Window.OpenStartupWindow",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "KeyboardShortcuts": {
-      "Command": "PixiEditor.Window.OpenShortcutWindow",
-      "DefaultShortcut": {
-        "key": "F7",
-        "modifiers": [
-            "Ctrl",
-            "Alt",
-            "Shift"
-        ]
-      },
-      "Parameters": []
-    },
-    "About": {
-      "Command": "PixiEditor.Window.OpenAboutWindow",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "TogglePreview": {
-      "Command": "PixiEditor.Window.OpenPreviewWindow",
-      "DefaultShortcut": {
-        "key": "F7",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Document.ClipCanvas",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "SymmetryMode.orientation=vertical": {
-      "Command": "PixiEditor.Document.ToggleVerticalSymmetryAxis",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "SymmetryMode.orientation=horizontal": {
-      "Command": "PixiEditor.Document.ToggleHorizontalSymmetryAxis",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "Clear": {
-      "Command": "PixiEditor.Document.DeleteSelected",
-      "DefaultShortcut": {
-        "key": "Delete",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "SpriteSize": {
-      "Command": "PixiEditor.Document.ResizeDocument",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "CanvasSize": {
-      "Command": "PixiEditor.Document.ResizeCanvas",
-      "DefaultShortcut": {
-        "key": "C",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "": {
-      "Command": "PixiEditor.Document.CenterContent",
-      "DefaultShortcut": {
-        "key": "None",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "eyedropper": {
-      "Command": "PixiEditor.Tools.Select.ColorPickerToolViewModel",
-      "DefaultShortcut": {
-        "key": "I",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "ellipse": {
-      "Command": "PixiEditor.Tools.Select.EllipseToolViewModel",
-      "DefaultShortcut": {
-        "key": "U",
-        "modifiers": [ "Shift" ]
-      },
-      "Parameters": []
-    },
-    "eraser": {
-      "Command": "PixiEditor.Tools.Select.EraserToolViewModel",
-      "DefaultShortcut": {
-        "key": "E",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "paint_bucket": {
-      "Command": "PixiEditor.Tools.Select.FloodFillToolViewModel",
-      "DefaultShortcut": {
-        "key": "G",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "lasso": {
-      "Command": "PixiEditor.Tools.Select.LassoToolViewModel",
-      "DefaultShortcut": {
-        "key": "Q",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "line": {
-      "Command": "PixiEditor.Tools.Select.LineToolViewModel",
-      "DefaultShortcut": {
-        "key": "L",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "magic_wand": {
-      "Command": "PixiEditor.Tools.Select.MagicWandToolViewModel",
-      "DefaultShortcut": {
-        "key": "W",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "move": {
-      "Command": "PixiEditor.Tools.Select.MoveToolViewModel",
-      "DefaultShortcut": {
-        "key": "V",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "hand": {
-      "Command": "PixiEditor.Tools.Select.MoveViewportToolViewModel",
-      "DefaultShortcut": {
-        "key": "H",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "pencil": {
-      "Command": "PixiEditor.Tools.Select.PenToolViewModel",
-      "DefaultShortcut": {
-        "key": "B",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "rectangle": {
-      "Command": "PixiEditor.Tools.Select.RectangleToolViewModel",
-      "DefaultShortcut": {
-        "key": "U",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "rectangular_marquee": {
-      "Command": "PixiEditor.Tools.Select.SelectToolViewModel",
-      "DefaultShortcut": {
-        "key": "M",
-        "modifiers": null
-      },
-      "Parameters": []
-    },
-    "zoom": {
-      "Command": "PixiEditor.Tools.Select.ZoomToolViewModel",
-      "DefaultShortcut": {
-        "key": "Z",
-        "modifiers": null
-      },
-      "Parameters": []
-    }
+  "Cut": {
+    "Commands": "PixiEditor.Clipboard.Cut",
+    "DefaultShortcut": {
+      "key": "X",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "Paste": {
+    "Commands": "PixiEditor.Clipboard.Paste",
+    "DefaultShortcut": {
+      "key": "V",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Clipboard.PasteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "Copy": {
+    "Commands": "PixiEditor.Clipboard.Copy",
+    "DefaultShortcut": {
+      "key": "C",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.OpenPaletteBrowser",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "LoadPalette": {
+    "Commands": "PixiEditor.Colors.ImportPalette",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.SelectFirstPaletteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.SelectSecondPaletteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.SelectThirdPaletteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.SelectFourthPaletteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.SelectFifthPaletteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.SelectSixthPaletteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.SelectSeventhPaletteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.SelectEighthPaletteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.SelectNinthPaletteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.SelectTenthPaletteColor",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "SwitchColors": {
+    "Commands": "PixiEditor.Colors.Swap",
+    "DefaultShortcut": {
+      "key": "X",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Colors.RemoveSwatch",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "NewFile": {
+    "Commands": "PixiEditor.File.New",
+    "DefaultShortcut": {
+      "key": "N",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "OpenFile": {
+    "Commands": "PixiEditor.File.Open",
+    "DefaultShortcut": {
+      "key": "O",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "Recent": {
+    "Commands": "PixiEditor.File.OpenRecent",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "SaveFile": {
+    "Commands": "PixiEditor.File.Save",
+    "DefaultShortcut": {
+      "key": "S",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "SaveFileAs": {
+    "Commands": "PixiEditor.File.SaveAsNew",
+    "DefaultShortcut": {
+      "key": "S",
+      "modifiers": [
+        "Ctrl",
+        "Shift"
+      ]
+    },
+    "Parameters": []
+  },
+  "SaveFileCopyAs": {
+    "Commands": "PixiEditor.File.Export",
+    "DefaultShortcut": {
+      "key": "S",
+      "modifiers": [
+        "Ctrl",
+        "Alt",
+        "Shift"
+      ]
+    },
+    "Parameters": []
+  },
+  "RemoveLayer": {
+    "Commands": "PixiEditor.Layer.DeleteAllSelected",
+    "DefaultShortcut": {
+      "key": "Delete",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "NewLayer.group=true": {
+    "Commands": "PixiEditor.Layer.NewFolder",
+    "DefaultShortcut": {
+      "key": "N",
+      "modifiers": [
+        "Alt",
+        "Shift"
+      ]
+    },
+    "Parameters": []
+  },
+  "NewLayer": {
+    "Commands": "PixiEditor.Layer.NewLayer",
+    "DefaultShortcut": {
+      "key": "N",
+      "modifiers": [
+        "Shift"
+      ]
+    },
+    "Parameters": []
+  },
+  "NewLayer.fromClipboard=true": {
+    "Commands": "PixiEditor.Clipboard.PasteAsNewLayer",
+    "DefaultShortcut": {
+      "key": "V",
+      "modifiers": [
+        "Ctrl",
+        "Shift"
+      ]
+    },
+    "Parameters": []
+  },
+  "SetInkType.type=lock-alpha": {
+    "Commands": "PixiEditor.Layer.ToggleLockTransparency",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "DuplicateLayer": {
+    "Commands": "PixiEditor.Layer.DuplicateSelectedMember",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Layer.CreateMask",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Layer.DeleteMask",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Layer.MoveSelectedMemberUpwards",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Layer.MoveSelectedMemberDownwards",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Layer.MergeSelected",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Layer.MergeWithAbove",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "MergeDownLayer": {
+    "Commands": "PixiEditor.Layer.MergeWithBelow",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "Launch.path=/docs/.type=url": {
+    "Commands": "PixiEditor.Links.OpenDocumentation",
+    "DefaultShortcut": {
+      "key": "B",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "MaskAll": {
+    "Commands": "PixiEditor.Selection.SelectAll",
+    "DefaultShortcut": {
+      "key": "A",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "DeselectMask": {
+    "Commands": "PixiEditor.Selection.Clear",
+    "DefaultShortcut": {
+      "key": "D",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Selection.TransformArea",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Stylus.TogglePenMode",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "ChangeBrush.change=increment-size": {
+    "Commands": "PixiEditor.Tools.IncreaseSize",
+    "DefaultShortcut": {
+      "key": "+",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "ChangeBrush.change=decrement-size": {
+    "Commands": "PixiEditor.Tools.DecreaseSize",
+    "DefaultShortcut": {
+      "key": "-",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "Redo": {
+    "Commands": "PixiEditor.Undo.Redo",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "Undo": {
+    "Commands": "PixiEditor.Undo.Undo",
+    "DefaultShortcut": {
+      "key": "Z",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "ShowGrid": {
+    "Commands": "PixiEditor.View.ToggleGrid",
+    "DefaultShortcut": {
+      "key": "'",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "Zoom.action=in": {
+    "Commands": "PixiEditor.View.ZoomIn",
+    "DefaultShortcut": {
+      "key": "+",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "Zoom.action=out": {
+    "Commands": "PixiEditor.View.Zoomout",
+    "DefaultShortcut": {
+      "key": "-",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Window.CreateNewViewport",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "Options": {
+    "Commands": "PixiEditor.Window.OpenSettingsWindow",
+    "DefaultShortcut": {
+      "key": "K",
+      "modifiers": [
+        "Ctrl"
+      ]
+    },
+    "Parameters": []
+  },
+  "Home": {
+    "Commands": "PixiEditor.Window.OpenStartupWindow",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "KeyboardShortcuts": {
+    "Commands": "PixiEditor.Window.OpenShortcutWindow",
+    "DefaultShortcut": {
+      "key": "F7",
+      "modifiers": [
+        "Ctrl",
+        "Alt",
+        "Shift"
+      ]
+    },
+    "Parameters": []
+  },
+  "About": {
+    "Commands": "PixiEditor.Window.OpenAboutWindow",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "TogglePreview": {
+    "Commands": "PixiEditor.Window.OpenPreviewWindow",
+    "DefaultShortcut": {
+      "key": "F7",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Document.ClipCanvas",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "SymmetryMode.orientation=vertical": {
+    "Commands": "PixiEditor.Document.ToggleVerticalSymmetryAxis",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "SymmetryMode.orientation=horizontal": {
+    "Commands": "PixiEditor.Document.ToggleHorizontalSymmetryAxis",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "Clear": {
+    "Commands": "PixiEditor.Document.DeleteSelected",
+    "DefaultShortcut": {
+      "key": "Delete",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "SpriteSize": {
+    "Commands": "PixiEditor.Document.ResizeDocument",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "CanvasSize": {
+    "Commands": "PixiEditor.Document.ResizeCanvas",
+    "DefaultShortcut": {
+      "key": "C",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "": {
+    "Commands": "PixiEditor.Document.CenterContent",
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "eyedropper": {
+    "Commands": "PixiEditor.Tools.Select.ColorPickerToolViewModel",
+    "DefaultShortcut": {
+      "key": "I",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "ellipse": {
+    "Commands": "PixiEditor.Tools.Select.RasterEllipseToolViewModel",
+    "DefaultShortcut": {
+      "key": "U",
+      "modifiers": [
+        "Shift"
+      ]
+    },
+    "Parameters": []
+  },
+  "eraser": {
+    "Commands": "PixiEditor.Tools.Select.EraserToolViewModel",
+    "DefaultShortcut": {
+      "key": "E",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "paint_bucket": {
+    "Commands": "PixiEditor.Tools.Select.FloodFillToolViewModel",
+    "DefaultShortcut": {
+      "key": "G",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "lasso": {
+    "Commands": "PixiEditor.Tools.Select.LassoToolViewModel",
+    "DefaultShortcut": {
+      "key": "Q",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "line": {
+    "Commands": "PixiEditor.Tools.Select.RasterLineToolViewModel",
+    "DefaultShortcut": {
+      "key": "L",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "magic_wand": {
+    "Commands": "PixiEditor.Tools.Select.MagicWandToolViewModel",
+    "DefaultShortcut": {
+      "key": "W",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "move": {
+    "Commands": "PixiEditor.Tools.Select.MoveToolViewModel",
+    "DefaultShortcut": {
+      "key": "V",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "hand": {
+    "Commands": "PixiEditor.Tools.Select.MoveViewportToolViewModel",
+    "DefaultShortcut": {
+      "key": "H",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "pencil": {
+    "Commands": "PixiEditor.Tools.Select.PenToolViewModel",
+    "DefaultShortcut": {
+      "key": "B",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "rectangle": {
+    "Commands": "PixiEditor.Tools.Select.RasterRectangleToolViewModel",
+    "DefaultShortcut": {
+      "key": "U",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "rectangular_marquee": {
+    "Commands": "PixiEditor.Tools.Select.SelectToolViewModel",
+    "DefaultShortcut": {
+      "key": "M",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "zoom": {
+    "Commands": "PixiEditor.Tools.Select.ZoomToolViewModel",
+    "DefaultShortcut": {
+      "key": "Z",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "NewFrame": {
+    "Commands": "PixiEditor.Animation.DuplicateCel",
+    "DefaultShortcut": {
+      "key": "N",
+      "modifiers": [ "Alt" ]
+    },
+    "Parameters": []
+  },
+  "NewFrame.content=empty": {
+    "Commands": "PixiEditor.Animation.DuplicateCel",
+    "DefaultShortcut": {
+      "key": "B",
+      "modifiers": [ "Alt" ]
+    },
+    "Parameters": []
+  },
+  "RemoveFrame": {
+    "Commands": "PixiEditor.Animation.DuplicateCel",
+    "DefaultShortcut": {
+      "key": "C",
+      "modifiers": [ "Alt" ]
+    },
+    "Parameters": []
   }
+}

--- a/src/PixiEditor/Data/ShortcutActionMaps/AsepriteShortcutMap.json
+++ b/src/PixiEditor/Data/ShortcutActionMaps/AsepriteShortcutMap.json
@@ -1,6 +1,8 @@
 ﻿{
   "Cut": {
-    "Commands": "PixiEditor.Clipboard.Cut",
+    "Commands": [
+      "PixiEditor.Clipboard.Cut"
+    ],
     "DefaultShortcut": {
       "key": "X",
       "modifiers": [
@@ -10,7 +12,11 @@
     "Parameters": []
   },
   "Paste": {
-    "Commands": "PixiEditor.Clipboard.Paste",
+    "Commands": [
+      "PixiEditor.Clipboard.Paste",
+      "PixiEditor.Clipboard.PasteNodes",
+      "PixiEditor.Clipboard.PasteCels"
+    ],
     "DefaultShortcut": {
       "key": "V",
       "modifiers": [
@@ -20,7 +26,9 @@
     "Parameters": []
   },
   "": {
-    "Commands": "PixiEditor.Clipboard.PasteColor",
+    "Commands": [
+      "PixiEditor.Document.CenterContent"
+    ],
     "DefaultShortcut": {
       "key": "None",
       "modifiers": null
@@ -28,7 +36,9 @@
     "Parameters": []
   },
   "Copy": {
-    "Commands": "PixiEditor.Clipboard.Copy",
+    "Commands": [
+      "PixiEditor.Clipboard.Copy"
+    ],
     "DefaultShortcut": {
       "key": "C",
       "modifiers": [
@@ -37,96 +47,10 @@
     },
     "Parameters": []
   },
-  "": {
-    "Commands": "PixiEditor.Colors.OpenPaletteBrowser",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
   "LoadPalette": {
-    "Commands": "PixiEditor.Colors.ImportPalette",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Colors.SelectFirstPaletteColor",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Colors.SelectSecondPaletteColor",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Colors.SelectThirdPaletteColor",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Colors.SelectFourthPaletteColor",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Colors.SelectFifthPaletteColor",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Colors.SelectSixthPaletteColor",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Colors.SelectSeventhPaletteColor",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Colors.SelectEighthPaletteColor",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Colors.SelectNinthPaletteColor",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Colors.SelectTenthPaletteColor",
+    "Commands": [
+      "PixiEditor.Colors.ImportPalette"
+    ],
     "DefaultShortcut": {
       "key": "None",
       "modifiers": null
@@ -134,23 +58,19 @@
     "Parameters": []
   },
   "SwitchColors": {
-    "Commands": "PixiEditor.Colors.Swap",
+    "Commands": [
+      "PixiEditor.Colors.Swap"
+    ],
     "DefaultShortcut": {
       "key": "X",
       "modifiers": null
     },
     "Parameters": []
   },
-  "": {
-    "Commands": "PixiEditor.Colors.RemoveSwatch",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
   "NewFile": {
-    "Commands": "PixiEditor.File.New",
+    "Commands": [
+      "PixiEditor.File.New"
+    ],
     "DefaultShortcut": {
       "key": "N",
       "modifiers": [
@@ -160,7 +80,9 @@
     "Parameters": []
   },
   "OpenFile": {
-    "Commands": "PixiEditor.File.Open",
+    "Commands": [
+      "PixiEditor.File.Open"
+    ],
     "DefaultShortcut": {
       "key": "O",
       "modifiers": [
@@ -170,7 +92,9 @@
     "Parameters": []
   },
   "Recent": {
-    "Commands": "PixiEditor.File.OpenRecent",
+    "Commands": [
+      "PixiEditor.File.OpenRecent"
+    ],
     "DefaultShortcut": {
       "key": "None",
       "modifiers": null
@@ -178,7 +102,9 @@
     "Parameters": []
   },
   "SaveFile": {
-    "Commands": "PixiEditor.File.Save",
+    "Commands": [
+      "PixiEditor.File.Save"
+    ],
     "DefaultShortcut": {
       "key": "S",
       "modifiers": [
@@ -188,7 +114,9 @@
     "Parameters": []
   },
   "SaveFileAs": {
-    "Commands": "PixiEditor.File.SaveAsNew",
+    "Commands": [
+      "PixiEditor.File.SaveAsNew"
+    ],
     "DefaultShortcut": {
       "key": "S",
       "modifiers": [
@@ -199,7 +127,9 @@
     "Parameters": []
   },
   "SaveFileCopyAs": {
-    "Commands": "PixiEditor.File.Export",
+    "Commands": [
+      "PixiEditor.File.Export"
+    ],
     "DefaultShortcut": {
       "key": "S",
       "modifiers": [
@@ -211,7 +141,9 @@
     "Parameters": []
   },
   "RemoveLayer": {
-    "Commands": "PixiEditor.Layer.DeleteAllSelected",
+    "Commands": [
+      "PixiEditor.Layer.DeleteAllSelected"
+    ],
     "DefaultShortcut": {
       "key": "Delete",
       "modifiers": null
@@ -219,7 +151,9 @@
     "Parameters": []
   },
   "NewLayer.group=true": {
-    "Commands": "PixiEditor.Layer.NewFolder",
+    "Commands": [
+      "PixiEditor.Layer.NewFolder"
+    ],
     "DefaultShortcut": {
       "key": "N",
       "modifiers": [
@@ -230,7 +164,9 @@
     "Parameters": []
   },
   "NewLayer": {
-    "Commands": "PixiEditor.Layer.NewLayer",
+    "Commands": [
+      "PixiEditor.Layer.NewLayer"
+    ],
     "DefaultShortcut": {
       "key": "N",
       "modifiers": [
@@ -240,7 +176,9 @@
     "Parameters": []
   },
   "NewLayer.fromClipboard=true": {
-    "Commands": "PixiEditor.Clipboard.PasteAsNewLayer",
+    "Commands": [
+      "PixiEditor.Clipboard.PasteAsNewLayer"
+    ],
     "DefaultShortcut": {
       "key": "V",
       "modifiers": [
@@ -251,7 +189,9 @@
     "Parameters": []
   },
   "SetInkType.type=lock-alpha": {
-    "Commands": "PixiEditor.Layer.ToggleLockTransparency",
+    "Commands": [
+      "PixiEditor.Layer.ToggleLockTransparency"
+    ],
     "DefaultShortcut": {
       "key": "None",
       "modifiers": null
@@ -259,55 +199,9 @@
     "Parameters": []
   },
   "DuplicateLayer": {
-    "Commands": "PixiEditor.Layer.DuplicateSelectedMember",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Layer.CreateMask",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Layer.DeleteMask",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Layer.MoveSelectedMemberUpwards",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Layer.MoveSelectedMemberDownwards",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Layer.MergeSelected",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Layer.MergeWithAbove",
+    "Commands": [
+      "PixiEditor.Layer.DuplicateSelectedMember"
+    ],
     "DefaultShortcut": {
       "key": "None",
       "modifiers": null
@@ -315,7 +209,9 @@
     "Parameters": []
   },
   "MergeDownLayer": {
-    "Commands": "PixiEditor.Layer.MergeWithBelow",
+    "Commands": [
+      "PixiEditor.Layer.MergeWithBelow"
+    ],
     "DefaultShortcut": {
       "key": "None",
       "modifiers": null
@@ -323,7 +219,9 @@
     "Parameters": []
   },
   "Launch.path=/docs/.type=url": {
-    "Commands": "PixiEditor.Links.OpenDocumentation",
+    "Commands": [
+      "PixiEditor.Links.OpenDocumentation"
+    ],
     "DefaultShortcut": {
       "key": "B",
       "modifiers": null
@@ -331,7 +229,9 @@
     "Parameters": []
   },
   "MaskAll": {
-    "Commands": "PixiEditor.Selection.SelectAll",
+    "Commands": [
+      "PixiEditor.Selection.SelectAll"
+    ],
     "DefaultShortcut": {
       "key": "A",
       "modifiers": [
@@ -341,7 +241,9 @@
     "Parameters": []
   },
   "DeselectMask": {
-    "Commands": "PixiEditor.Selection.Clear",
+    "Commands": [
+      "PixiEditor.Selection.Clear"
+    ],
     "DefaultShortcut": {
       "key": "D",
       "modifiers": [
@@ -350,24 +252,10 @@
     },
     "Parameters": []
   },
-  "": {
-    "Commands": "PixiEditor.Selection.TransformArea",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
-  "": {
-    "Commands": "PixiEditor.Stylus.TogglePenMode",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
   "ChangeBrush.change=increment-size": {
-    "Commands": "PixiEditor.Tools.IncreaseSize",
+    "Commands": [
+      "PixiEditor.Tools.IncreaseSize"
+    ],
     "DefaultShortcut": {
       "key": "+",
       "modifiers": null
@@ -375,7 +263,9 @@
     "Parameters": []
   },
   "ChangeBrush.change=decrement-size": {
-    "Commands": "PixiEditor.Tools.DecreaseSize",
+    "Commands": [
+      "PixiEditor.Tools.DecreaseSize"
+    ],
     "DefaultShortcut": {
       "key": "-",
       "modifiers": null
@@ -383,9 +273,11 @@
     "Parameters": []
   },
   "Redo": {
-    "Commands": "PixiEditor.Undo.Redo",
+    "Commands": [
+      "PixiEditor.Undo.Redo"
+    ],
     "DefaultShortcut": {
-      "key": "None",
+      "key": "Y",
       "modifiers": [
         "Ctrl"
       ]
@@ -393,7 +285,9 @@
     "Parameters": []
   },
   "Undo": {
-    "Commands": "PixiEditor.Undo.Undo",
+    "Commands": [
+      "PixiEditor.Undo.Undo"
+    ],
     "DefaultShortcut": {
       "key": "Z",
       "modifiers": [
@@ -403,7 +297,9 @@
     "Parameters": []
   },
   "ShowGrid": {
-    "Commands": "PixiEditor.View.ToggleGrid",
+    "Commands": [
+      "PixiEditor.View.ToggleGrid"
+    ],
     "DefaultShortcut": {
       "key": "'",
       "modifiers": [
@@ -413,7 +309,9 @@
     "Parameters": []
   },
   "Zoom.action=in": {
-    "Commands": "PixiEditor.View.ZoomIn",
+    "Commands": [
+      "PixiEditor.View.ZoomIn"
+    ],
     "DefaultShortcut": {
       "key": "+",
       "modifiers": [
@@ -423,7 +321,9 @@
     "Parameters": []
   },
   "Zoom.action=out": {
-    "Commands": "PixiEditor.View.Zoomout",
+    "Commands": [
+      "PixiEditor.View.Zoomout"
+    ],
     "DefaultShortcut": {
       "key": "-",
       "modifiers": [
@@ -432,16 +332,10 @@
     },
     "Parameters": []
   },
-  "": {
-    "Commands": "PixiEditor.Window.CreateNewViewport",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
   "Options": {
-    "Commands": "PixiEditor.Window.OpenSettingsWindow",
+    "Commands": [
+      "PixiEditor.Window.OpenSettingsWindow"
+    ],
     "DefaultShortcut": {
       "key": "K",
       "modifiers": [
@@ -451,7 +345,9 @@
     "Parameters": []
   },
   "Home": {
-    "Commands": "PixiEditor.Window.OpenStartupWindow",
+    "Commands": [
+      "PixiEditor.Window.OpenStartupWindow"
+    ],
     "DefaultShortcut": {
       "key": "None",
       "modifiers": null
@@ -459,7 +355,9 @@
     "Parameters": []
   },
   "KeyboardShortcuts": {
-    "Commands": "PixiEditor.Window.OpenShortcutWindow",
+    "Commands": [
+      "PixiEditor.Window.OpenShortcutWindow"
+    ],
     "DefaultShortcut": {
       "key": "F7",
       "modifiers": [
@@ -471,7 +369,9 @@
     "Parameters": []
   },
   "About": {
-    "Commands": "PixiEditor.Window.OpenAboutWindow",
+    "Commands": [
+      "PixiEditor.Window.OpenAboutWindow"
+    ],
     "DefaultShortcut": {
       "key": "None",
       "modifiers": null
@@ -479,23 +379,19 @@
     "Parameters": []
   },
   "TogglePreview": {
-    "Commands": "PixiEditor.Window.OpenPreviewWindow",
+    "Commands": [
+      "PixiEditor.Window.OpenPreviewWindow"
+    ],
     "DefaultShortcut": {
       "key": "F7",
       "modifiers": null
     },
     "Parameters": []
   },
-  "": {
-    "Commands": "PixiEditor.Document.ClipCanvas",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
   "SymmetryMode.orientation=vertical": {
-    "Commands": "PixiEditor.Document.ToggleVerticalSymmetryAxis",
+    "Commands": [
+      "PixiEditor.Document.ToggleVerticalSymmetryAxis"
+    ],
     "DefaultShortcut": {
       "key": "None",
       "modifiers": null
@@ -503,7 +399,9 @@
     "Parameters": []
   },
   "SymmetryMode.orientation=horizontal": {
-    "Commands": "PixiEditor.Document.ToggleHorizontalSymmetryAxis",
+    "Commands": [
+      "PixiEditor.Document.ToggleHorizontalSymmetryAxis"
+    ],
     "DefaultShortcut": {
       "key": "None",
       "modifiers": null
@@ -511,7 +409,10 @@
     "Parameters": []
   },
   "Clear": {
-    "Commands": "PixiEditor.Document.DeleteSelected",
+    "Commands": [
+      "PixiEditor.Document.DeleteSelected",
+      "PixiEditor.Layer.DeleteAllSelected"
+    ],
     "DefaultShortcut": {
       "key": "Delete",
       "modifiers": null
@@ -519,31 +420,32 @@
     "Parameters": []
   },
   "SpriteSize": {
-    "Commands": "PixiEditor.Document.ResizeDocument",
+    "Commands": [
+      "PixiEditor.Document.ResizeDocument"
+    ],
     "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
+      "key": "I",
+      "modifiers": [
+        "Ctrl",
+        "Alt"
+      ]
     },
     "Parameters": []
   },
   "CanvasSize": {
-    "Commands": "PixiEditor.Document.ResizeCanvas",
+    "Commands": [
+      "PixiEditor.Document.ResizeCanvas"
+    ],
     "DefaultShortcut": {
       "key": "C",
       "modifiers": null
     },
     "Parameters": []
   },
-  "": {
-    "Commands": "PixiEditor.Document.CenterContent",
-    "DefaultShortcut": {
-      "key": "None",
-      "modifiers": null
-    },
-    "Parameters": []
-  },
   "eyedropper": {
-    "Commands": "PixiEditor.Tools.Select.ColorPickerToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.ColorPickerToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "I",
       "modifiers": null
@@ -551,7 +453,9 @@
     "Parameters": []
   },
   "ellipse": {
-    "Commands": "PixiEditor.Tools.Select.RasterEllipseToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.RasterEllipseToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "U",
       "modifiers": [
@@ -561,7 +465,9 @@
     "Parameters": []
   },
   "eraser": {
-    "Commands": "PixiEditor.Tools.Select.EraserToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.EraserToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "E",
       "modifiers": null
@@ -569,7 +475,9 @@
     "Parameters": []
   },
   "paint_bucket": {
-    "Commands": "PixiEditor.Tools.Select.FloodFillToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.FloodFillToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "G",
       "modifiers": null
@@ -577,7 +485,9 @@
     "Parameters": []
   },
   "lasso": {
-    "Commands": "PixiEditor.Tools.Select.LassoToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.LassoToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "Q",
       "modifiers": null
@@ -585,7 +495,9 @@
     "Parameters": []
   },
   "line": {
-    "Commands": "PixiEditor.Tools.Select.RasterLineToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.RasterLineToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "L",
       "modifiers": null
@@ -593,7 +505,9 @@
     "Parameters": []
   },
   "magic_wand": {
-    "Commands": "PixiEditor.Tools.Select.MagicWandToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.MagicWandToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "W",
       "modifiers": null
@@ -601,7 +515,9 @@
     "Parameters": []
   },
   "move": {
-    "Commands": "PixiEditor.Tools.Select.MoveToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.MoveToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "V",
       "modifiers": null
@@ -609,7 +525,9 @@
     "Parameters": []
   },
   "hand": {
-    "Commands": "PixiEditor.Tools.Select.MoveViewportToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.MoveViewportToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "H",
       "modifiers": null
@@ -617,7 +535,9 @@
     "Parameters": []
   },
   "pencil": {
-    "Commands": "PixiEditor.Tools.Select.PenToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.PenToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "B",
       "modifiers": null
@@ -625,7 +545,9 @@
     "Parameters": []
   },
   "rectangle": {
-    "Commands": "PixiEditor.Tools.Select.RasterRectangleToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.RasterRectangleToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "U",
       "modifiers": null
@@ -633,7 +555,9 @@
     "Parameters": []
   },
   "rectangular_marquee": {
-    "Commands": "PixiEditor.Tools.Select.SelectToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.SelectToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "M",
       "modifiers": null
@@ -641,7 +565,9 @@
     "Parameters": []
   },
   "zoom": {
-    "Commands": "PixiEditor.Tools.Select.ZoomToolViewModel",
+    "Commands": [
+      "PixiEditor.Tools.Select.ZoomToolViewModel"
+    ],
     "DefaultShortcut": {
       "key": "Z",
       "modifiers": null
@@ -649,26 +575,84 @@
     "Parameters": []
   },
   "NewFrame": {
-    "Commands": "PixiEditor.Animation.DuplicateCel",
+    "Commands": [
+      "PixiEditor.Animation.DuplicateCel"
+    ],
     "DefaultShortcut": {
       "key": "N",
-      "modifiers": [ "Alt" ]
+      "modifiers": [
+        "Alt"
+      ]
     },
     "Parameters": []
   },
   "NewFrame.content=empty": {
-    "Commands": "PixiEditor.Animation.DuplicateCel",
+    "Commands": [
+      "PixiEditor.Animation.CreateCel"
+    ],
     "DefaultShortcut": {
       "key": "B",
-      "modifiers": [ "Alt" ]
+      "modifiers": [
+        "Alt"
+      ]
     },
     "Parameters": []
   },
   "RemoveFrame": {
-    "Commands": "PixiEditor.Animation.DuplicateCel",
+    "Commands": [
+      "PixiEditor.Animation.DuplicateCel"
+    ],
     "DefaultShortcut": {
       "key": "C",
-      "modifiers": [ "Alt" ]
+      "modifiers": [
+        "Alt"
+      ]
+    },
+    "Parameters": []
+  },
+  "AutocropSprite": {
+    "Commands": [
+      "PixiEditor.Document.ClipCanvas"
+    ],
+    "DefaultShortcut": {
+      "key": "None",
+      "modifiers": null
+    },
+    "Parameters": []
+  },
+  "Flip.orientation=horizontal.target=mask": {
+    "Commands": [
+      "PixiEditor.Document.FlipImageHorizontal"
+    ],
+    "DefaultShortcut": {
+      "key": "H",
+      "modifiers": [
+        "Shift"
+      ]
+    },
+    "Parameters": []
+  },
+  "Flip.orientation=vertical.target=mask": {
+    "Commands": [
+      "PixiEditor.Document.FlipImageVertical"
+    ],
+    "DefaultShortcut": {
+      "key": "V",
+      "modifiers": [
+        "Shift"
+      ]
+    },
+    "Parameters": []
+  },
+  "AdvancedMode": {
+    "Commands": [
+      "PixiEditor.Viewport.ToggleHud"
+    ],
+    "DefaultShortcut": {
+      "key": "F",
+      "modifiers": [
+        "Ctrl"
+      ]
     },
     "Parameters": []
   }

--- a/src/PixiEditor/Models/Commands/ShortcutsTemplate.cs
+++ b/src/PixiEditor/Models/Commands/ShortcutsTemplate.cs
@@ -20,7 +20,10 @@ public sealed class ShortcutsTemplate
         ShortcutsTemplate template = new ShortcutsTemplate();
         foreach (KeyDefinition keyDefinition in keyDefinitions)
         {
-            template.Shortcuts.Add(new Shortcut(keyDefinition.DefaultShortcut.ToKeyCombination(), keyDefinition.Command));
+            foreach (string command in keyDefinition.Commands)
+            {
+                template.Shortcuts.Add(new Shortcut(keyDefinition.DefaultShortcut.ToKeyCombination(), command));
+            }
         }
 
         return template;

--- a/src/PixiEditor/Models/Commands/ShortcutsTemplate.cs
+++ b/src/PixiEditor/Models/Commands/ShortcutsTemplate.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using Avalonia.Input;
 using PixiEditor.Models.Commands.Templates.Providers.Parsers;
 using PixiEditor.Models.Input;
@@ -31,6 +32,7 @@ public sealed class ShortcutsTemplate
 }
 
 [Serializable]
+[DebuggerDisplay("KeyCombination = {KeyCombination}, Commands = {Commands}")]
 public sealed class Shortcut
 {
     public KeyCombination KeyCombination { get; set; }

--- a/src/PixiEditor/Models/Commands/Templates/Providers/Parsers/AsepriteKeysParser.cs
+++ b/src/PixiEditor/Models/Commands/Templates/Providers/Parsers/AsepriteKeysParser.cs
@@ -38,9 +38,10 @@ public class AsepriteKeysParser : KeysParser
 
         if (Path.GetExtension(path) != ".aseprite-keys")
         {
-            throw new InvalidFileTypeException("FILE_FORMAT_NOT_ASEPRITE_KEYS", $"File {path} is not an aseprite-keys file");
+            throw new InvalidFileTypeException("FILE_FORMAT_NOT_ASEPRITE_KEYS",
+                $"File {path} is not an aseprite-keys file");
         }
-        
+
         return LoadAndParse(path, applyDefaults);
     }
 
@@ -60,7 +61,7 @@ public class AsepriteKeysParser : KeysParser
         {
             throw new RecoverableException("FAILED_TO_OPEN_FILE", e);
         }
-        
+
         List<KeyDefinition> keyDefinitions = new List<KeyDefinition>(); // DefaultShortcut is actually mapped shortcut.
 
         LoadCommands(doc, keyDefinitions, applyDefaults);
@@ -87,57 +88,60 @@ public class AsepriteKeysParser : KeysParser
 
         foreach (XmlNode commandNode in commands)
         {
-            if(commandNode.Attributes == null) continue;
-            
+            if (commandNode.Attributes == null) continue;
+
             XmlAttribute command = commandNode.Attributes["command"];
             XmlAttribute shortcut = commandNode.Attributes["shortcut"];
             XmlNodeList paramNodes = commandNode.SelectNodes("param");
 
-            if(command == null || shortcut == null) continue;
+            if (command == null || shortcut == null) continue;
 
             string commandName = $"{command.Value}{GetParamString(paramNodes)}";
             string shortcutValue = shortcut.Value;
-            
+
             if (!Map.ContainsKey(commandName))
             {
                 continue;
             }
 
             var mappedEntry = Map[commandName];
-            commandName = mappedEntry.Command;
-            
-            HumanReadableKeyCombination combination;
-            
-            XmlAttribute removed = commandNode.Attributes["removed"];
-            if (removed is { Value: "true" })
+            foreach (var mappedCommand in mappedEntry.Commands)
             {
-                combination = new HumanReadableKeyCombination("None");
-            }
-            else
-            {
-                combination = HumanReadableKeyCombination.FromStringCombination(shortcutValue);
-            }
+                commandName = mappedCommand;
 
-            // We should override existing entry, because aseprite-keys file can contain multiple entries for the same command.
-            // Last one is the one that should be used.
-            keyDefinitions.RemoveAll(x => x.Command == commandName);
-            
-            keyDefinitions.Add(new KeyDefinition(commandName, combination));
+                HumanReadableKeyCombination combination;
+
+                XmlAttribute removed = commandNode.Attributes["removed"];
+                if (removed is { Value: "true" })
+                {
+                    combination = new HumanReadableKeyCombination("None");
+                }
+                else
+                {
+                    combination = HumanReadableKeyCombination.FromStringCombination(shortcutValue);
+                }
+
+                // We should override existing entry, because aseprite-keys file can contain multiple entries for the same command.
+                // Last one is the one that should be used.
+                keyDefinitions.RemoveAll(x => x.Commands.Contains(commandName));
+
+                keyDefinitions.Add(new KeyDefinition(new[] { commandName }, combination));
+            }
         }
     }
 
     private string GetParamString(XmlNodeList paramNodes)
     {
-        if(paramNodes == null || paramNodes.Count == 0) return string.Empty;
-        
+        if (paramNodes == null || paramNodes.Count == 0) return string.Empty;
+
         StringBuilder builder = new StringBuilder();
         foreach (XmlNode paramNode in paramNodes)
         {
-            if(paramNode.Attributes == null) continue;
-            
+            if (paramNode.Attributes == null) continue;
+
             XmlAttribute paramName = paramNode.Attributes["name"];
             XmlAttribute paramValue = paramNode.Attributes["value"];
-            if(paramName == null || paramValue == null) continue;
+            if (paramName == null || paramValue == null) continue;
 
             builder.Append('.');
             builder.Append(paramName.Value);
@@ -163,12 +167,12 @@ public class AsepriteKeysParser : KeysParser
 
         foreach (XmlNode tool in tools)
         {
-            if(tool.Attributes == null) continue;
-            
+            if (tool.Attributes == null) continue;
+
             XmlAttribute command = tool.Attributes["tool"];
             XmlAttribute shortcut = tool.Attributes["shortcut"];
 
-            if(command == null || shortcut == null) continue;
+            if (command == null || shortcut == null) continue;
 
             string commandName = command.Value;
             string shortcutValue = shortcut.Value;
@@ -179,25 +183,28 @@ public class AsepriteKeysParser : KeysParser
             }
 
             var mappedEntry = Map[commandName];
-            commandName = mappedEntry.Command;
-
-            HumanReadableKeyCombination combination;
-            
-            XmlAttribute removed = tool.Attributes["removed"];
-            if (removed is { Value: "true" })
+            foreach (var mappedCommand in mappedEntry.Commands)
             {
-                combination = new HumanReadableKeyCombination("None");
-            }
-            else
-            {
-                combination = HumanReadableKeyCombination.FromStringCombination(shortcutValue);
-            }
+                commandName = mappedCommand;
 
-            // We should override existing entry, because aseprite-keys file can contain multiple entries for the same tool.
-            // Last one is the one that should be used.
-            keyDefinitions.RemoveAll(x => x.Command == commandName);
-            
-            keyDefinitions.Add(new KeyDefinition(commandName, combination));
+                HumanReadableKeyCombination combination;
+
+                XmlAttribute removed = tool.Attributes["removed"];
+                if (removed is { Value: "true" })
+                {
+                    combination = new HumanReadableKeyCombination("None");
+                }
+                else
+                {
+                    combination = HumanReadableKeyCombination.FromStringCombination(shortcutValue);
+                }
+
+                // We should override existing entry, because aseprite-keys file can contain multiple entries for the same tool.
+                // Last one is the one that should be used.
+                keyDefinitions.RemoveAll(x => x.Commands.Contains(commandName));
+
+                keyDefinitions.Add(new KeyDefinition(new[] { commandName }, combination));
+            }
         }
     }
 
@@ -205,9 +212,12 @@ public class AsepriteKeysParser : KeysParser
     {
         foreach (var mapEntry in Map)
         {
-            if (mapEntry.Value.Command.StartsWith(commandGroup))
+            foreach (var command in mapEntry.Value.Commands)
             {
-                keyDefinitions.Add(mapEntry.Value);
+                if (command.StartsWith(commandGroup))
+                {
+                    keyDefinitions.Add(mapEntry.Value);
+                }
             }
         }
     }

--- a/src/PixiEditor/Models/Commands/Templates/Providers/Parsers/KeyDefinition.cs
+++ b/src/PixiEditor/Models/Commands/Templates/Providers/Parsers/KeyDefinition.cs
@@ -6,14 +6,14 @@ namespace PixiEditor.Models.Commands.Templates.Providers.Parsers;
 [Serializable]
 public class KeyDefinition
 {
-    public string Command { get; set; }
+    public string[] Commands { get; set; }
     public HumanReadableKeyCombination DefaultShortcut { get; set; }
     public string[] Parameters { get; set; }
     
     public KeyDefinition() { }
-    public KeyDefinition(string command, HumanReadableKeyCombination defaultShortcut, params string[] parameters)
+    public KeyDefinition(string[] commands, HumanReadableKeyCombination defaultShortcut, params string[] parameters)
     {
-        Command = command;
+        Commands = commands;
         DefaultShortcut = defaultShortcut;
         Parameters = parameters;
     }

--- a/src/PixiEditor/Models/Commands/Templates/Providers/Parsers/KeysParser.cs
+++ b/src/PixiEditor/Models/Commands/Templates/Providers/Parsers/KeysParser.cs
@@ -14,10 +14,10 @@ public abstract class KeysParser
 
     public Dictionary<string, KeyDefinition> Map => _cachedMap ??= LoadKeysMap();
     private Dictionary<string, KeyDefinition> _cachedMap;
-    
+
     public List<Shortcut> Defaults => _cachedDefaults ??= ParseDefaults();
     private List<Shortcut> _cachedDefaults;
-    
+
     public KeysParser(string mapFileName)
     {
         if (mapFileName.StartsWith("avares://"))
@@ -28,7 +28,7 @@ public abstract class KeysParser
         {
             SetPathOrThrow(mapFileName);
         }
-        
+
         MapFileName = mapFileName;
     }
 
@@ -57,13 +57,13 @@ public abstract class KeysParser
     /// <param name="applyTemplateDefaults">If true, all shortcuts available in the key map will be loaded, and then overwritten by entries in the file. If false, only entries from the file will be applied.</param>
     /// <returns>Parsed ShortcutTemplate.</returns>
     public abstract ShortcutsTemplate Parse(string filePath, bool applyTemplateDefaults);
-    
+
     private Dictionary<string, KeyDefinition> LoadKeysMap()
     {
         string text = ReadMap();
         var dict = JsonConvert.DeserializeObject<Dictionary<string, KeyDefinition>>(text);
-        if(dict == null) throw new Exception("Keys map file is empty.");
-        if(dict.ContainsKey("")) dict.Remove("");
+        if (dict == null) throw new Exception("Keys map file is empty.");
+        if (dict.ContainsKey("")) dict.Remove("");
         return dict;
     }
 
@@ -86,10 +86,13 @@ public abstract class KeysParser
         {
             if (value.DefaultShortcut != null)
             {
-                defaults.Add(new Shortcut(value.DefaultShortcut.ToKeyCombination(), Map[key].Command));
+                foreach (var keyCommand in Map[key].Commands)
+                {
+                    defaults.Add(new Shortcut(value.DefaultShortcut.ToKeyCombination(), keyCommand));
+                }
             }
         }
-        
+
         return defaults;
     }
 }

--- a/src/PixiEditor/ViewModels/SubViewModels/DebugViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/DebugViewModel.cs
@@ -206,7 +206,7 @@ internal class DebugViewModel : SubViewModel<ViewModelMain>
                     if (command.IsDebug)
                         continue;
                     keyDefinitions.Add($"(provider).{command.InternalName}",
-                        new KeyDefinition(command.InternalName, new HumanReadableKeyCombination("None"),
+                        new KeyDefinition([command.InternalName], new HumanReadableKeyCombination("None"),
                             Array.Empty<string>()));
                 }
 
@@ -252,9 +252,12 @@ internal class DebugViewModel : SubViewModel<ViewModelMain>
 
                 foreach (var keyDefinition in keyDefinitions)
                 {
-                    if (!Owner.CommandController.Commands.ContainsKey(keyDefinition.Value.Command))
+                    foreach (var command in keyDefinition.Value.Commands)
                     {
-                        unknownCommands++;
+                        if (!Owner.CommandController.Commands.ContainsKey(command))
+                        {
+                            unknownCommands++;
+                        }
                     }
                 }
 
@@ -461,10 +464,8 @@ internal class DebugViewModel : SubViewModel<ViewModelMain>
         if (File.Exists(file))
         {
             OptionsDialog<string> dialog =
-                new("ARE_YOU_SURE", $"Are you sure you want to overwrite {path}\n(Full Path: {file})", MainWindow.Current)
-                {
-                    { "Yes", x => File.Delete(file) }, "Cancel"
-                };
+                new("ARE_YOU_SURE", $"Are you sure you want to overwrite {path}\n(Full Path: {file})",
+                    MainWindow.Current) { { "Yes", x => File.Delete(file) }, "Cancel" };
 
             dialog.ShowDialog();
         }


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

- Fixed crash when changing bold/italic in text
- Updated Aseprite Shortcut map and import logic

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
