### PR TITLE
Fixed NullReferenceException in LinuxOSInformation.FromRelaseFile()

### DIFF
--- a/src/PixiEditor.Linux/LinuxOperatingSystem.cs
+++ b/src/PixiEditor.Linux/LinuxOperatingSystem.cs
@@ -51,34 +51,33 @@ public sealed class LinuxOperatingSystem : IOperatingSystem
     {
         const string FilePath = "/etc/os-release";
         
-        private LinuxOSInformation(string? name, string? version, bool available)
+        private LinuxOSInformation(string? name, string? version)
         {
             Name = name;
             Version = version;
-            Available = available;
         }
 
         public static LinuxOSInformation FromReleaseFile()
         {
             if (!File.Exists(FilePath))
             {
-                return new LinuxOSInformation(null, null, false);
+                return new LinuxOSInformation(null, null);
             }
             
             // Parse /etc/os-release file (e.g. 'NAME="Ubuntu"')
-            var lines = File.ReadAllLines(FilePath).Select<string, (string Key, string Value)>(x =>
+            var lines = File.ReadAllLines(FilePath).Select<string, (string? Key, string Value)>(line =>
             {
-                var separatorIndex = x.IndexOf('=');
-                return (x[..separatorIndex], x[(separatorIndex + 1)..]);
+                var separatorIndex = line.IndexOf('=');
+                return (line[..separatorIndex], line[(separatorIndex + 1)..]);
             }).ToList();
             
-            var name = lines.FirstOrDefault(x => x.Key == "NAME").Value.Trim('"');
-            var version = lines.FirstOrDefault(x => x.Key == "VERSION").Value.Trim('"');
+            var name = GetKeyValue("NAME") ?? GetKeyValue("ID");
+            var version = GetKeyValue("VERSION");
             
-            return new LinuxOSInformation(name, version, true);
+            return new LinuxOSInformation(name, version);
+
+            string? GetKeyValue(string key) => lines.FirstOrDefault(x => x.Key?.ToUpper() == key).Value?.Trim('"');
         }
-        
-        public bool Available { get; }
         
         public string? Name { get; private set; }
         

--- a/src/PixiEditor.Linux/LinuxOperatingSystem.cs
+++ b/src/PixiEditor.Linux/LinuxOperatingSystem.cs
@@ -68,7 +68,10 @@ public sealed class LinuxOperatingSystem : IOperatingSystem
             var lines = File.ReadAllLines(FilePath).Select<string, (string? Key, string Value)>(line =>
             {
                 var separatorIndex = line.IndexOf('=');
-                return (line[..separatorIndex], line[(separatorIndex + 1)..]);
+                
+                return separatorIndex != -1 
+                    ? (line[..separatorIndex], line[(separatorIndex + 1)..])
+                    : (null, null);
             }).ToList();
             
             var name = GetKeyValue("NAME") ?? GetKeyValue("ID");


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

There were instances (Analytics Issue Id 202) where LinuxOSInformation.FromRelaseFile() would throw

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at PixiEditor.Linux.LinuxOperatingSystem.LinuxOSInformation.FromReleaseFile()
   at PixiEditor.Linux.LinuxOperatingSystem.get_AnalyticsName()
   at PixiEditor.Models.ExceptionHandling.CrashReport.Generate(Exception exception, NonCrashInfo nonCrashInfo)
```

I added null operators to hopefully prevent the exception and also added "ID" as a fallback to ID

Example File

```
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

 ## If possible, show examples of usage

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
