### PR TITLE
Fixed non latin crash report file paths

### DIFF
--- a/src/PixiEditor/Initialization/ClassicDesktopEntry.cs
+++ b/src/PixiEditor/Initialization/ClassicDesktopEntry.cs
@@ -61,7 +61,7 @@ internal class ClassicDesktopEntry
 
         InitOperatingSystem();
 
-        if (ParseArgument("--crash (\"?)([A-z0-9:\\/\\ -_.]+)\\1", arguments, out Group[] groups))
+        if (ParseArgument(@"--crash (""?)([\w:\/\ -_.]+)\1", arguments, out Group[] groups))
         {
             try
             {


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

The previous regex only captured A-z 0-9 characters when parsing program arguments which did not capture cyrillic characters

This fixes PixiAnalytics Issue 48: DirectoryNotFoundException

 ## If possible, show examples of usage

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
