### PR TITLE
Don't always send a exception on FileViewModel.OpenFromReport(...)

### DIFF
--- a/src/PixiEditor/ViewModels/SubViewModels/FileViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/FileViewModel.cs
@@ -441,8 +441,13 @@ internal class FileViewModel : SubViewModel<ViewModelMain>
                 }
             }
 
-            var exceptions = new[] { firstException, secondException, thirdException };
-            CrashHelper.SendExceptionInfo(new AggregateException(exceptions.Where(x => x != null).ToArray()));
+            var exceptions = new[] { firstException, secondException, thirdException }
+                .Where(x => x != null).ToArray();
+
+            if (exceptions.Length > 0)
+            {
+                CrashHelper.SendExceptionInfo(new AggregateException(exceptions));
+            }
         }
 
         showMissingFilesDialog = documents.Count != i;

--- a/src/PixiEditor/ViewModels/SubViewModels/FileViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/FileViewModel.cs
@@ -405,12 +405,12 @@ internal class FileViewModel : SubViewModel<ViewModelMain>
 
         var i = 0;
 
-        Exception firstException = null;
-        Exception secondException = null;
-        Exception thirdException = null;
-
         foreach (var document in documents)
         {
+            Exception firstException = null;
+            Exception secondException = null;
+            Exception thirdException = null;
+
             try
             {
                 OpenRecoveredDotPixi(document.OriginalPath, document.AutosavePath,


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible
 
Fixed always sending an AggregateException when opening documents from a crash report

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
