### PR TITLE
Fixes/15.04.2025

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/VectorLayerNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/VectorLayerNode.cs
@@ -120,7 +120,7 @@ public class VectorLayerNode : LayerNode, ITransformableObject, IReadOnlyVectorN
         if (!context.ProcessingColorSpace.IsSrgb)
         {
             int saved = renderOn.Canvas.Save();
-            Texture tex = Texture.ForProcessing(renderOn, ColorSpace.CreateSrgb());
+            using Texture tex = Texture.ForProcessing(renderOn, ColorSpace.CreateSrgb());
             renderOn.Canvas.SetMatrix(Matrix3X3.Identity);
             Rasterize(tex.DrawingSurface, paint);
             renderOn.Canvas.DrawSurface(tex.DrawingSurface, 0, 0);

--- a/src/PixiEditor/ViewModels/Document/StructureTree.cs
+++ b/src/PixiEditor/ViewModels/Document/StructureTree.cs
@@ -96,7 +96,8 @@ internal class StructureTree
             if (oldRoot != root)
             {
                 oldRoot.Remove(member);
-                root.Insert(relativeIndex, member);
+                int clampIndex = Math.Clamp(relativeIndex, 0, root.Count);
+                root.Insert(clampIndex, member);
                 _memberMap[member] = root;
             }
         }


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

- Fixed vector layer preview memory leak
- Fixed index out of bounds crash in StructureTree

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
