### PR TITLE
Fixes/16.04.2025

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/InputProperty.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/InputProperty.cs
@@ -39,7 +39,14 @@ public class InputProperty : IInputProperty
 
             if (!ValueType.IsAssignableTo(typeof(Delegate)) && connectionValue is Delegate connectionField)
             {
-                return connectionField.DynamicInvoke(FuncContext.NoContext);
+                try
+                {
+                    return connectionField.DynamicInvoke(FuncContext.NoContext);
+                }
+                catch
+                {
+                    return null;
+                }
             }
 
             if (ValueType.IsAssignableTo(typeof(Delegate)) && connectionValue is not Delegate)
@@ -217,7 +224,7 @@ public class InputProperty : IInputProperty
         HashCode hash = new();
         hash.Add(InternalPropertyName);
         hash.Add(ValueType);
-        if(Value is ICacheable cacheable)
+        if (Value is ICacheable cacheable)
         {
             hash.Add(cacheable.GetCacheHash());
         }

--- a/src/PixiEditor/ViewModels/Document/DocumentViewModel.cs
+++ b/src/PixiEditor/ViewModels/Document/DocumentViewModel.cs
@@ -1113,6 +1113,8 @@ internal partial class DocumentViewModel : PixiObservableObject, IDocument
         int firstFrame = 0;
         int lastFrame = AnimationDataViewModel.GetVisibleFramesCount();
 
+        lastFrame = Math.Max(1, lastFrame);
+
         if (keyFrames.Count > 0)
         {
             firstFrame = AnimationDataViewModel.GetFirstVisibleFrame();


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

- Fixed a saving error when trying to export a video without any animation frames
- Added a null check to prevent crashes in some cases

_Include the link to the related issues if relevant_ 

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
