### PR TITLE
Fixes/22.04.2025

### DIFF
--- a/src/PixiEditor.Extensions.CommonApi/UserPreferences/PreferencesConstants.cs
+++ b/src/PixiEditor.Extensions.CommonApi/UserPreferences/PreferencesConstants.cs
@@ -33,6 +33,14 @@ public static class PreferencesConstants
 
     public const string AnalyticsEnabled = "AnalyticsEnabled";
     public const bool AnalyticsEnabledDefault = true;
+
     public const string PrimaryToolset = "PrimaryToolset";
     public const string PrimaryToolsetDefault = "PAINT_TOOLSET";
+
+    public const string AutoScaleBackground = "AutoScaleBackground";
+    public const bool AutoScaleBackgroundDefault = true;
+
+    public const string CustomBackgroundScaleX = "CustomBackgroundScaleX";
+    public const string CustomBackgroundScaleY = "CustomBackgroundScaleY";
+    public const double CustomBackgroundScaleDefault = 16;
 }

--- a/src/PixiEditor.Extensions.CommonApi/UserPreferences/PreferencesConstants.cs
+++ b/src/PixiEditor.Extensions.CommonApi/UserPreferences/PreferencesConstants.cs
@@ -43,4 +43,11 @@ public static class PreferencesConstants
     public const string CustomBackgroundScaleX = "CustomBackgroundScaleX";
     public const string CustomBackgroundScaleY = "CustomBackgroundScaleY";
     public const double CustomBackgroundScaleDefault = 16;
+
+    public const string PrimaryBackgroundColorDefault = "#616161";
+    public const string PrimaryBackgroundColor = "PrimaryBackgroundColor";
+
+    public const string SecondaryBackgroundColorDefault = "#353535";
+    public const string SecondaryBackgroundColor = "SecondaryBackgroundColor";
+
 }

--- a/src/PixiEditor.Extensions.CommonApi/UserPreferences/Settings/PixiEditor/PixiEditorSettings.cs
+++ b/src/PixiEditor.Extensions.CommonApi/UserPreferences/Settings/PixiEditor/PixiEditorSettings.cs
@@ -77,5 +77,9 @@ public static class PixiEditorSettings
         public static SyncedSetting<bool> AutoScaleBackground { get; } = SyncedSetting.NonOwned(PixiEditor, PreferencesConstants.AutoScaleBackgroundDefault, PreferencesConstants.AutoScaleBackground);
         public static SyncedSetting<double> CustomBackgroundScaleX { get; } = SyncedSetting.NonOwned(PixiEditor, PreferencesConstants.CustomBackgroundScaleDefault, PreferencesConstants.CustomBackgroundScaleX);
         public static SyncedSetting<double> CustomBackgroundScaleY { get; } = SyncedSetting.NonOwned(PixiEditor, PreferencesConstants.CustomBackgroundScaleDefault, PreferencesConstants.CustomBackgroundScaleY);
+
+        public static SyncedSetting<string> PrimaryBackgroundColor { get; } = SyncedSetting.NonOwned(PixiEditor, PreferencesConstants.PrimaryBackgroundColorDefault, PreferencesConstants.PrimaryBackgroundColor);
+        public static SyncedSetting<string> SecondaryBackgroundColor { get; } = SyncedSetting.NonOwned(PixiEditor, PreferencesConstants.SecondaryBackgroundColorDefault, PreferencesConstants.SecondaryBackgroundColor);
+
     }
 }

--- a/src/PixiEditor.Extensions.CommonApi/UserPreferences/Settings/PixiEditor/PixiEditorSettings.cs
+++ b/src/PixiEditor.Extensions.CommonApi/UserPreferences/Settings/PixiEditor/PixiEditorSettings.cs
@@ -71,4 +71,11 @@ public static class PixiEditorSettings
     {
         public static SyncedSetting<bool> AnalyticsEnabled { get; } = SyncedSetting.NonOwned(PixiEditor, true);
     }
+
+    public static class Scene
+    {
+        public static SyncedSetting<bool> AutoScaleBackground { get; } = SyncedSetting.NonOwned(PixiEditor, PreferencesConstants.AutoScaleBackgroundDefault, PreferencesConstants.AutoScaleBackground);
+        public static SyncedSetting<double> CustomBackgroundScaleX { get; } = SyncedSetting.NonOwned(PixiEditor, PreferencesConstants.CustomBackgroundScaleDefault, PreferencesConstants.CustomBackgroundScaleX);
+        public static SyncedSetting<double> CustomBackgroundScaleY { get; } = SyncedSetting.NonOwned(PixiEditor, PreferencesConstants.CustomBackgroundScaleDefault, PreferencesConstants.CustomBackgroundScaleY);
+    }
 }

--- a/src/PixiEditor/Data/Configs/ToolSetsConfig.json
+++ b/src/PixiEditor/Data/Configs/ToolSetsConfig.json
@@ -17,7 +17,12 @@
       "Select",
       "MagicWand",
       "Lasso",
-      "FloodFill",
+      {
+        "ToolName": "FloodFill",
+        "Settings": {
+          "Tolerance": 0
+        }
+      },
       "RasterLine",
       "RasterEllipse",
       "RasterRectangle",

--- a/src/PixiEditor/Data/Localization/Languages/en.json
+++ b/src/PixiEditor/Data/Localization/Languages/en.json
@@ -1025,5 +1025,9 @@
   "ONB_SHORTCUTS": "Select Your Shortcuts",
   "GRAPH_STATE_UNABLE_TO_CREATE_MEMBER": "Current Node Graph setup disallows creation of a new layer next to the selected one.",
   "PRIMARY_TOOLSET": "Primary Toolset",
-  "OPEN_ONBOARDING_WINDOW": "Open onboarding window"
+  "OPEN_ONBOARDING_WINDOW": "Open onboarding window",
+  "AUTO_SCALE_BACKGROUND": "Auto scale background",
+  "UPDATES": "Updates",
+  "SCENE": "Scene",
+  "CUSTOM_BACKGROUND_SCALE": "Custom background scale",
 }

--- a/src/PixiEditor/Data/Localization/Languages/en.json
+++ b/src/PixiEditor/Data/Localization/Languages/en.json
@@ -1030,4 +1030,7 @@
   "UPDATES": "Updates",
   "SCENE": "Scene",
   "CUSTOM_BACKGROUND_SCALE": "Custom background scale",
+  "PRIMARY_BG_COLOR": "Primary background color",
+  "SECONDARY_BG_COLOR": "Secondary background color",
+  "RESET": "Reset"
 }

--- a/src/PixiEditor/Data/Localization/Languages/en.json
+++ b/src/PixiEditor/Data/Localization/Languages/en.json
@@ -783,7 +783,7 @@
   "PATH_TOOL_TOOLTIP": "Create vector paths and curves ({0}).",
   "PATH_TOOL_ACTION_DISPLAY": "Click to add a point.",
   "PATH_TOOL_ACTION_DISPLAY_CTRL": "Click on existing point and drag to make it a curve. Tap on a control point to select it.",
-  "PATH_TOOL_ACTION_DISPLAY_SHIFT": "Click on a path to insert a point.",
+  "PATH_TOOL_ACTION_DISPLAY_SHIFT": "Click to create a new layer.",
   "PATH_TOOL_ACTION_DISPLAY_CTRL_SHIFT": "Tap on a control point to add it to the selection.",
   "PATH_TOOL_ACTION_DISPLAY_ALT": "Click on a control point and move to adjust only one side of the curve.",
   "DEFAULT_PATH_LAYER_NAME": "Path",

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorPathToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorPathToolExecutor.cs
@@ -137,7 +137,7 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
 
     public override void OnLeftMouseButtonDown(MouseOnCanvasEventArgs args)
     {
-        if (args.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        if (args.KeyModifiers.HasFlag(KeyModifiers.Shift) || NeedsNewLayer(member, document.AnimationHandler.ActiveFrameTime))
         {
             Guid? created =
                 document.Operations.CreateStructureMember(typeof(VectorLayerNode), ActionSource.Automated);
@@ -148,11 +148,15 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
         }
     }
 
-    private bool WholePathClosed()
+    private bool NeedsNewLayer(IStructureMemberHandler? member, KeyFrameTime frameTime)
     {
-        EditableVectorPath editablePath = new EditableVectorPath(startingPath);
+        var shapeData = (member as IVectorLayerHandler).GetShapeData(frameTime);
+        if (shapeData is null)
+        {
+            return false;
+        }
 
-        return editablePath.SubShapes.Count > 0 && editablePath.SubShapes.All(x => x.IsClosed);
+        return shapeData is not IReadOnlyPathData pathData;
     }
 
     public override void OnLeftMouseButtonUp(VecD pos)

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorPathToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorPathToolExecutor.cs
@@ -137,18 +137,14 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
 
     public override void OnLeftMouseButtonDown(MouseOnCanvasEventArgs args)
     {
-        bool allClosed = WholePathClosed();
-        if (!isValidPathLayer || allClosed)
+        if (args.KeyModifiers.HasFlag(KeyModifiers.Shift))
         {
-            if (NeedsNewLayer(document.SelectedStructureMember, document.AnimationHandler.ActiveFrameTime))
-            {
-                Guid? created =
-                    document.Operations.CreateStructureMember(typeof(VectorLayerNode), ActionSource.Automated);
+            Guid? created =
+                document.Operations.CreateStructureMember(typeof(VectorLayerNode), ActionSource.Automated);
 
-                if (created is null) return;
+            if (created is null) return;
 
-                document.Operations.SetSelectedMember(created.Value);
-            }
+            document.Operations.SetSelectedMember(created.Value);
         }
     }
 
@@ -205,7 +201,8 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
     private void AddToUndo(VectorPath path)
     {
         internals.ActionAccumulator.AddFinishedActions(new EndSetShapeGeometry_Action(),
-            new SetShapeGeometry_Action(member.Id, ConstructShapeData(path), VectorShapeChangeType.GeometryData), new EndSetShapeGeometry_Action());
+            new SetShapeGeometry_Action(member.Id, ConstructShapeData(path), VectorShapeChangeType.GeometryData),
+            new EndSetShapeGeometry_Action());
     }
 
     private PathVectorData ConstructShapeData(VectorPath? path)
@@ -257,17 +254,6 @@ internal class VectorPathToolExecutor : UpdateableChangeExecutor, IPathExecutorF
         document!.SnappingHandler.SnappingController.HighlightedXAxis = snapX;
         document!.SnappingHandler.SnappingController.HighlightedYAxis = snapY;
         document.SnappingHandler.SnappingController.HighlightedPoint = null;
-    }
-
-    private bool NeedsNewLayer(IStructureMemberHandler? member, KeyFrameTime frameTime)
-    {
-        var shapeData = (member as IVectorLayerHandler).GetShapeData(frameTime);
-        if (shapeData is null)
-        {
-            return false;
-        }
-
-        return shapeData is not IReadOnlyPathData pathData || pathData.Path.IsClosed;
     }
 
     private void ApplySettings(PathVectorData pathData)

--- a/src/PixiEditor/ViewModels/SettingsWindowViewModel.cs
+++ b/src/PixiEditor/ViewModels/SettingsWindowViewModel.cs
@@ -270,7 +270,9 @@ internal partial class SettingsWindowViewModel : ViewModelBase
             new("GENERAL"),
             new("DISCORD"),
             new("KEY_BINDINGS"),
+            new SettingsPage("UPDATES"),
             new("EXPORT"),
+            new SettingsPage("SCENE")
         };
 
         ILocalizationProvider.Current.OnLanguageChanged += OnLanguageChanged;

--- a/src/PixiEditor/ViewModels/SubViewModels/ToolsViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/ToolsViewModel.cs
@@ -344,7 +344,7 @@ internal class ToolsViewModel : SubViewModel<ViewModelMain>, IToolsHandler
         CanExecute = "PixiEditor.Tools.CanChangeToolSize", Key = Key.OemOpenBrackets, AnalyticsTrack = true)]
     public void ChangeToolSize(double increment)
     {
-        if (ActiveTool?.Toolbar is not IToolSizeToolbar toolbar)
+        if (ActiveTool?.Toolbar is not IToolSizeToolbar toolbar || !CanChangeToolSize())
             return;
         double newSize = toolbar.ToolSize + increment;
         if (newSize > 0)

--- a/src/PixiEditor/ViewModels/UserPreferences/Settings/SceneSettings.cs
+++ b/src/PixiEditor/ViewModels/UserPreferences/Settings/SceneSettings.cs
@@ -1,0 +1,28 @@
+﻿using Drawie.Numerics;
+using PixiEditor.Extensions.CommonApi.UserPreferences;
+
+namespace PixiEditor.ViewModels.UserPreferences.Settings;
+
+internal class SceneSettings : SettingsGroup
+{
+    private bool autoScaleBackground = GetPreference(PreferencesConstants.AutoScaleBackground, PreferencesConstants.AutoScaleBackgroundDefault);
+    public bool AutoScaleBackground
+    {
+        get => autoScaleBackground;
+        set => RaiseAndUpdatePreference(ref autoScaleBackground, value);
+    }
+
+    private double customBackgroundScaleX = GetPreference(PreferencesConstants.CustomBackgroundScaleX, PreferencesConstants.CustomBackgroundScaleDefault);
+    public double CustomBackgroundScaleX
+    {
+        get => customBackgroundScaleX;
+        set => RaiseAndUpdatePreference(ref customBackgroundScaleX, value);
+    }
+
+    private double customBackgroundScaleY = GetPreference(PreferencesConstants.CustomBackgroundScaleY, PreferencesConstants.CustomBackgroundScaleDefault);
+    public double CustomBackgroundScaleY
+    {
+        get => customBackgroundScaleY;
+        set => RaiseAndUpdatePreference(ref customBackgroundScaleY, value);
+    }
+}

--- a/src/PixiEditor/ViewModels/UserPreferences/Settings/SceneSettings.cs
+++ b/src/PixiEditor/ViewModels/UserPreferences/Settings/SceneSettings.cs
@@ -1,5 +1,9 @@
-﻿using Drawie.Numerics;
+﻿using System.Windows.Input;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.Input;
+using Drawie.Numerics;
 using PixiEditor.Extensions.CommonApi.UserPreferences;
+using PixiEditor.Helpers.Extensions;
 
 namespace PixiEditor.ViewModels.UserPreferences.Settings;
 
@@ -24,5 +28,42 @@ internal class SceneSettings : SettingsGroup
     {
         get => customBackgroundScaleY;
         set => RaiseAndUpdatePreference(ref customBackgroundScaleY, value);
+    }
+
+    private string _primaryBackgroundColorHex = GetPreference(PreferencesConstants.PrimaryBackgroundColor, PreferencesConstants.PrimaryBackgroundColorDefault);
+    public string PrimaryBackgroundColorHex
+    {
+        get => _primaryBackgroundColorHex;
+        set => RaiseAndUpdatePreference(ref _primaryBackgroundColorHex, value, PreferencesConstants.PrimaryBackgroundColor);
+    }
+
+    private string _secondaryBackgroundColorHex = GetPreference(PreferencesConstants.SecondaryBackgroundColor, PreferencesConstants.SecondaryBackgroundColorDefault);
+    public string SecondaryBackgroundColorHex
+    {
+        get => _secondaryBackgroundColorHex;
+        set => RaiseAndUpdatePreference(ref _secondaryBackgroundColorHex, value, PreferencesConstants.SecondaryBackgroundColor);
+    }
+
+    public Color PrimaryBackgroundColor
+    {
+        get => Color.Parse(PrimaryBackgroundColorHex);
+        set => PrimaryBackgroundColorHex = value.ToColor().ToRgbHex();
+    }
+
+    public Color SecondaryBackgroundColor
+    {
+        get => Color.Parse(SecondaryBackgroundColorHex);
+        set => SecondaryBackgroundColorHex = value.ToColor().ToRgbHex();
+    }
+
+    public ICommand ResetBackgroundCommand { get; }
+
+    public SceneSettings()
+    {
+        ResetBackgroundCommand = new RelayCommand(() =>
+        {
+            PrimaryBackgroundColorHex = PreferencesConstants.PrimaryBackgroundColorDefault;
+            SecondaryBackgroundColorHex = PreferencesConstants.SecondaryBackgroundColorDefault;
+        });
     }
 }

--- a/src/PixiEditor/ViewModels/UserPreferences/SettingsViewModel.cs
+++ b/src/PixiEditor/ViewModels/UserPreferences/SettingsViewModel.cs
@@ -15,6 +15,8 @@ internal class SettingsViewModel : SubViewModel<SettingsWindowViewModel>
 
     public DiscordSettings Discord { get; set; } = new();
 
+    public SceneSettings Scene { get; set; } = new();
+
     public SettingsViewModel(SettingsWindowViewModel owner)
         : base(owner)
     {

--- a/src/PixiEditor/Views/Dock/DocumentTemplate.axaml
+++ b/src/PixiEditor/Views/Dock/DocumentTemplate.axaml
@@ -40,6 +40,9 @@
         SnappingEnabled="{Binding ViewportSubViewModel.SnappingEnabled, Source={viewModels1:MainVM}, Mode=TwoWay}"
         AvailableRenderOutputs="{Binding ActiveDocument.NodeGraph.AvailableRenderOutputs, Source={viewModels1:MainVM DocumentManagerSVM}}"
         ViewportRenderOutput="{Binding RenderOutputName, Mode=TwoWay}"
+        AutoBackgroundScale="{Binding AutoScaleBackground, Mode=OneWay}"
+        CustomBackgroundScaleX="{Binding CustomBackgroundScaleX, Mode=OneWay}"
+        CustomBackgroundScaleY="{Binding CustomBackgroundScaleY, Mode=OneWay}"
         HudVisible="{Binding HudVisible}"
         Document="{Binding Document}">
     </viewportControls:Viewport>

--- a/src/PixiEditor/Views/Dock/DocumentTemplate.axaml
+++ b/src/PixiEditor/Views/Dock/DocumentTemplate.axaml
@@ -43,6 +43,7 @@
         AutoBackgroundScale="{Binding AutoScaleBackground, Mode=OneWay}"
         CustomBackgroundScaleX="{Binding CustomBackgroundScaleX, Mode=OneWay}"
         CustomBackgroundScaleY="{Binding CustomBackgroundScaleY, Mode=OneWay}"
+        BackgroundBitmap="{Binding BackgroundBitmap, Mode=OneWay}"
         HudVisible="{Binding HudVisible}"
         Document="{Binding Document}">
     </viewportControls:Viewport>

--- a/src/PixiEditor/Views/Input/SizeInput.axaml.cs
+++ b/src/PixiEditor/Views/Input/SizeInput.axaml.cs
@@ -13,11 +13,11 @@ internal partial class SizeInput : UserControl
     public static readonly StyledProperty<double> SizeProperty =
         AvaloniaProperty.Register<SizeInput, double>(nameof(Size), defaultValue: 1);
 
-    public static readonly StyledProperty<int> MinSizeProperty = AvaloniaProperty.Register<SizeInput, int>(
+    public static readonly StyledProperty<double> MinSizeProperty = AvaloniaProperty.Register<SizeInput, double>(
         nameof(MinSize), defaultValue: 1);
 
-    public static readonly StyledProperty<int> MaxSizeProperty =
-        AvaloniaProperty.Register<SizeInput, int>(nameof(MaxSize), defaultValue: int.MaxValue);
+    public static readonly StyledProperty<double> MaxSizeProperty =
+        AvaloniaProperty.Register<SizeInput, double>(nameof(MaxSize), defaultValue: double.MaxValue);
 
     public static readonly StyledProperty<bool> BehaveLikeSmallEmbeddedFieldProperty =
         AvaloniaProperty.Register<SizeInput, bool>(nameof(BehaveLikeSmallEmbeddedField), defaultValue: true);
@@ -58,13 +58,13 @@ internal partial class SizeInput : UserControl
         set => SetValue(SizeProperty, value);
     }
 
-    public int MinSize
+    public double MinSize
     {
         get => GetValue(MinSizeProperty);
         set => SetValue(MinSizeProperty, value);
     }
 
-    public int MaxSize
+    public double MaxSize
     {
         get => (int)GetValue(MaxSizeProperty);
         set => SetValue(MaxSizeProperty, value);

--- a/src/PixiEditor/Views/Layers/LayerControl.axaml
+++ b/src/PixiEditor/Views/Layers/LayerControl.axaml
@@ -42,6 +42,7 @@
                 <RowDefinition Height="10" />
                 <RowDefinition Height="26" />
             </Grid.RowDefinitions>
+            <Panel Grid.ColumnSpan="2" Grid.RowSpan="2" Name="BackgroundGrid" Background="Transparent" DragDrop.AllowDrop="True"/>
             <Grid DragDrop.AllowDrop="True"
                   Name="TopGrid"
                   Grid.Row="0" Grid.ColumnSpan="3" Background="Transparent" />

--- a/src/PixiEditor/Views/Layers/LayerControl.axaml.cs
+++ b/src/PixiEditor/Views/Layers/LayerControl.axaml.cs
@@ -89,6 +89,7 @@ internal partial class LayerControl : UserControl
         TopGrid.AddHandler(DragDrop.DragEnterEvent, Grid_DragEnter);
         TopGrid.AddHandler(DragDrop.DragLeaveEvent, Grid_DragLeave);
         TopGrid.AddHandler(DragDrop.DropEvent, Grid_Drop_Top);
+        BackgroundGrid.AddHandler(DragDrop.DropEvent, BackgroundGrid_Drop);
         dropBelowGrid.AddHandler(DragDrop.DragEnterEvent, Grid_DragEnter);
         dropBelowGrid.AddHandler(DragDrop.DragLeaveEvent, Grid_DragLeave);
         dropBelowGrid.AddHandler(DragDrop.DropEvent, Grid_Drop_Below);
@@ -136,6 +137,11 @@ internal partial class LayerControl : UserControl
             RemoveDragEffect(item);
     }
 
+    private void BackgroundGrid_Drop(object sender, DragEventArgs e)
+    {
+        e.Handled = true;
+    }
+
     public static Guid[]? ExtractMemberGuids(IDataObject droppedMemberDataObject)
     {
         object droppedLayer = droppedMemberDataObject.Get(LayersManager.LayersDataName);
@@ -163,7 +169,7 @@ internal partial class LayerControl : UserControl
         if (Layer is null)
             return false;
 
-        if(placement is StructureMemberPlacement.Below or StructureMemberPlacement.BelowOutsideFolder)
+        if (placement is StructureMemberPlacement.Below or StructureMemberPlacement.BelowOutsideFolder)
         {
             droppedMemberGuids = droppedMemberGuids.Reverse().ToArray();
         }

--- a/src/PixiEditor/Views/Layers/LayersManager.axaml
+++ b/src/PixiEditor/Views/Layers/LayersManager.axaml
@@ -35,6 +35,7 @@
                     Height="24" Width="24" Cursor="Hand" uiExt:Translator.TooltipKey="NEW_LAYER"
                     HorizontalAlignment="Stretch" Margin="0,0,5,0"
                     Classes="pixi-icon"
+                    Focusable="False"
                     Content="{DynamicResource icon-file-plus}"
                     FlowDirection="LeftToRight"/>
                 <Button 
@@ -43,6 +44,7 @@
                     DockPanel.Dock="Left"
                     HorizontalAlignment="Stretch"  Margin="0,0,5,0"
                     Classes="pixi-icon"
+                    Focusable="False"
                     Content="{DynamicResource icon-folder-plus}"
                     FlowDirection="LeftToRight"/>
                 <Button 
@@ -51,6 +53,7 @@
                     HorizontalAlignment="Stretch" Margin="0,0,5,0"
                     DockPanel.Dock="Left"
                     Classes="pixi-icon"
+                    Focusable="False"
                     Content="{DynamicResource icon-trash}"
                     FlowDirection="LeftToRight"/>
                 <Button 
@@ -58,6 +61,7 @@
                     DockPanel.Dock="Right"
                     HorizontalAlignment="Stretch" Margin="5,0,0,0"
                     Classes="pixi-icon"
+                    Focusable="False"
                     Content="{DynamicResource icon-merge}"
                     FlowDirection="LeftToRight"/>
                 <Button 
@@ -65,6 +69,7 @@
                     DockPanel.Dock="Right"
                     HorizontalAlignment="Stretch" Margin="5,0,0,0"
                     Classes="pixi-icon"
+                    Focusable="False"
                     Content="{DynamicResource icon-create-mask}"
                     Command="{xaml:Command PixiEditor.Layer.CreateMask}"
                     FlowDirection="LeftToRight"/>
@@ -73,6 +78,7 @@
                     DockPanel.Dock="Right"
                     HorizontalAlignment="Stretch" Margin="5,0,0,0"
                     Classes="pixi-icon"
+                    Focusable="False"
                     Content="{DynamicResource icon-alpha-lock}"
                     Command="{xaml:Command PixiEditor.Layer.ToggleLockTransparency}"
                     FlowDirection="LeftToRight"/>

--- a/src/PixiEditor/Views/Main/Tools/ToolPickerButton.axaml
+++ b/src/PixiEditor/Views/Main/Tools/ToolPickerButton.axaml
@@ -16,6 +16,7 @@
     </Design.DataContext>
     <Button Command="{xaml:Command PixiEditor.Tools.SelectTool, UseProvided=true}"
             CommandParameter="{Binding}"
+            Focusable="False"
             Width="44" Height="34"
             ui:Translator.TooltipLocalizedString="{Binding Tooltip}"
             Background="{DynamicResource ThemeBackgroundBrush1}">

--- a/src/PixiEditor/Views/Main/ViewportControls/Viewport.axaml
+++ b/src/PixiEditor/Views/Main/ViewportControls/Viewport.axaml
@@ -43,9 +43,10 @@
                                         PassEventArgsToCommand="True"/>
             </EventTriggerBehavior>-->
         </Interaction.Behaviors>
-        <overlays:TogglableFlyout IsVisible="{Binding HudVisible, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}}" 
-                                  Margin="5" Icon="{DynamicResource icon-tool}"
-                                  ZIndex="2" HorizontalAlignment="Right" VerticalAlignment="Top">
+        <overlays:TogglableFlyout
+            IsVisible="{Binding HudVisible, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}}"
+            Margin="5" Icon="{DynamicResource icon-tool}"
+            ZIndex="2" HorizontalAlignment="Right" VerticalAlignment="Top">
             <overlays:TogglableFlyout.Child>
                 <Border Padding="5"
                         CornerRadius="{DynamicResource ControlCornerRadius}"
@@ -112,7 +113,7 @@
                                           IsChecked="{Binding FlipX, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=TwoWay}"
                                           Content="{DynamicResource icon-y-flip}"
                                           Cursor="Hand" />
-                            <ToggleButton  Width="32" Height="32"
+                            <ToggleButton Width="32" Height="32"
                                           ui:Translator.TooltipKey="FLIP_VIEWPORT_VERTICALLY"
                                           Classes="OverlayToggleButton pixi-icon"
                                           IsChecked="{Binding FlipY, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=TwoWay}"
@@ -135,7 +136,7 @@
                         </StackPanel>
                         <Separator />
                         <TextBlock HorizontalAlignment="Center"
-                                   ui:Translator.Key="GRIDLINES_SIZE" Margin="0 0 0 10"/>
+                                   ui:Translator.Key="GRIDLINES_SIZE" Margin="0 0 0 10" />
                         <input:NumberInput Min="1"
                                            Max="1024"
                                            Value="{Binding GridLinesXSize, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=TwoWay}" />
@@ -160,7 +161,8 @@
                 </Border>
             </overlays:TogglableFlyout.Child>
         </overlays:TogglableFlyout>
-        <Grid IsVisible="{Binding HudVisible, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}}"
+        <Grid
+            IsVisible="{Binding HudVisible, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}}"
             ZIndex="100" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="10">
             <Grid.RowDefinitions>
                 <RowDefinition MinHeight="40" MaxHeight="120" />
@@ -206,6 +208,9 @@
             FadeOut="{Binding Source={viewModels:ToolVM ColorPickerToolViewModel}, Path=PickOnlyFromReferenceLayer, Mode=OneWay}"
             DefaultCursor="{Binding Source={viewModels:MainVM}, Path=ToolsSubViewModel.ToolCursor, Mode=OneWay}"
             RenderOutput="{Binding ViewportRenderOutput, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=OneWay}"
+            AutoBackgroundScale="{Binding AutoBackgroundScale, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=OneWay}"
+            CustomBackgroundScaleX="{Binding CustomBackgroundScaleX, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=OneWay}"
+            CustomBackgroundScaleY="{Binding CustomBackgroundScaleY, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=OneWay}"
             CheckerImagePath="/Images/CheckerTile.png"
             PointerPressed="Scene_OnContextMenuOpening"
             ui:RenderOptionsBindable.BitmapInterpolationMode="{Binding Scale, Converter={converters:ScaleToBitmapScalingModeConverter}, RelativeSource={RelativeSource Self}}">

--- a/src/PixiEditor/Views/Main/ViewportControls/Viewport.axaml
+++ b/src/PixiEditor/Views/Main/ViewportControls/Viewport.axaml
@@ -211,7 +211,7 @@
             AutoBackgroundScale="{Binding AutoBackgroundScale, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=OneWay}"
             CustomBackgroundScaleX="{Binding CustomBackgroundScaleX, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=OneWay}"
             CustomBackgroundScaleY="{Binding CustomBackgroundScaleY, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=OneWay}"
-            CheckerImagePath="/Images/CheckerTile.png"
+            BackgroundBitmap="{Binding BackgroundBitmap, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=viewportControls:Viewport}, Mode=OneWay}"
             PointerPressed="Scene_OnContextMenuOpening"
             ui:RenderOptionsBindable.BitmapInterpolationMode="{Binding Scale, Converter={converters:ScaleToBitmapScalingModeConverter}, RelativeSource={RelativeSource Self}}">
             <rendering:Scene.ContextFlyout>

--- a/src/PixiEditor/Views/Main/ViewportControls/Viewport.axaml.cs
+++ b/src/PixiEditor/Views/Main/ViewportControls/Viewport.axaml.cs
@@ -13,6 +13,7 @@ using PixiEditor.ViewModels;
 using PixiEditor.Views.Visuals;
 using Drawie.Backend.Core;
 using Drawie.Backend.Core.Numerics;
+using Drawie.Backend.Core.Surfaces;
 using PixiEditor.Helpers.Behaviours;
 using PixiEditor.Helpers.UI;
 using PixiEditor.Models.Controllers.InputDevice;
@@ -122,6 +123,15 @@ internal partial class Viewport : UserControl, INotifyPropertyChanged
 
     public static readonly StyledProperty<double> CustomBackgroundScaleYProperty = AvaloniaProperty.Register<Viewport, double>(
         nameof(CustomBackgroundScaleY));
+
+    public static readonly StyledProperty<Bitmap> BackgroundBitmapProperty = AvaloniaProperty.Register<Viewport, Bitmap>(
+        nameof(BackgroundBitmap));
+
+    public Bitmap BackgroundBitmap
+    {
+        get => GetValue(BackgroundBitmapProperty);
+        set => SetValue(BackgroundBitmapProperty, value);
+    }
 
     public double CustomBackgroundScaleY
     {

--- a/src/PixiEditor/Views/Main/ViewportControls/Viewport.axaml.cs
+++ b/src/PixiEditor/Views/Main/ViewportControls/Viewport.axaml.cs
@@ -114,6 +114,32 @@ internal partial class Viewport : UserControl, INotifyPropertyChanged
     public static readonly StyledProperty<bool> HighResPreviewProperty =
         AvaloniaProperty.Register<Viewport, bool>(nameof(HighResPreview), true);
 
+    public static readonly StyledProperty<bool> AutoBackgroundScaleProperty = AvaloniaProperty.Register<Viewport, bool>(
+        nameof(AutoBackgroundScale), true);
+
+    public static readonly StyledProperty<double> CustomBackgroundScaleXProperty = AvaloniaProperty.Register<Viewport, double>(
+        nameof(CustomBackgroundScaleX));
+
+    public static readonly StyledProperty<double> CustomBackgroundScaleYProperty = AvaloniaProperty.Register<Viewport, double>(
+        nameof(CustomBackgroundScaleY));
+
+    public double CustomBackgroundScaleY
+    {
+        get => GetValue(CustomBackgroundScaleYProperty);
+        set => SetValue(CustomBackgroundScaleYProperty, value);
+    }
+    public double CustomBackgroundScaleX
+    {
+        get => GetValue(CustomBackgroundScaleXProperty);
+        set => SetValue(CustomBackgroundScaleXProperty, value);
+    }
+
+    public bool AutoBackgroundScale
+    {
+        get => GetValue(AutoBackgroundScaleProperty);
+        set => SetValue(AutoBackgroundScaleProperty, value);
+    }
+
     public SnappingViewModel SnappingViewModel
     {
         get => GetValue(SnappingViewModelProperty);

--- a/src/PixiEditor/Views/Overlays/Handles/AnchorHandle.cs
+++ b/src/PixiEditor/Views/Overlays/Handles/AnchorHandle.cs
@@ -14,7 +14,7 @@ public class AnchorHandle : RectangleHandle
     private Paint selectedPaint;
     
     public bool IsSelected { get; set; } = false;
-    public override VecD HitSizeMargin { get; set; } = new VecD(5, 5);
+    public override VecD HitSizeMargin { get; set; } = new VecD(10, 10);
 
     public AnchorHandle(Overlay owner) : base(owner)
     {

--- a/src/PixiEditor/Views/Overlays/Handles/ControlPointHandle.cs
+++ b/src/PixiEditor/Views/Overlays/Handles/ControlPointHandle.cs
@@ -9,6 +9,8 @@ public class ControlPointHandle : Handle
 {
     public Handle ConnectedTo { get; set; }
 
+    public override VecD HitSizeMargin { get; set; } = new VecD(10);
+
     public ControlPointHandle(IOverlay owner) : base(owner)
     {
         Size = new VecD(GetResource<double>("AnchorHandleSize"));

--- a/src/PixiEditor/Views/Overlays/PathOverlay/EditableVectorPath.cs
+++ b/src/PixiEditor/Views/Overlays/PathOverlay/EditableVectorPath.cs
@@ -65,7 +65,7 @@ public class EditableVectorPath
         {
             newPath = new VectorPath();
         }
-        
+
         newPath.FillType = FillType;
 
         foreach (var subShape in subShapes)
@@ -307,7 +307,7 @@ public class EditableVectorPath
         return closest;
     }
 
-    public void AddPointAt(VecD point)
+    public int? AddPointAt(VecD point)
     {
         SubShape targetSubShape = null;
         Verb verb = null;
@@ -321,8 +321,24 @@ public class EditableVectorPath
             }
         }
 
-        targetSubShape?.InsertPointAt((VecF)point, verb);
+        if (targetSubShape != null)
+        {
+            int localIndex = targetSubShape.InsertPointAt((VecF)point, verb);
+            int globalIndex = GetGlobalIndex(targetSubShape, localIndex);
+            return globalIndex;
+        }
+
+        return null;
     }
+
+    /*
+    public void NewSubShape(VecD point)
+    {
+        VecF pointF = (VecF)point;
+        ShapePoint newPoint = new ShapePoint(pointF, 0, new Verb(PathVerb.Move, pointF, pointF, null, null, 0));
+        var newSubShape = new SubShape(new List<ShapePoint>() { newPoint }, false);
+        subShapes.Add(newSubShape);
+    }*/
 
     public void RemoveSubShape(SubShape subShapeContainingIndex)
     {

--- a/src/PixiEditor/Views/Overlays/PathOverlay/SubShape.cs
+++ b/src/PixiEditor/Views/Overlays/PathOverlay/SubShape.cs
@@ -52,7 +52,7 @@ public class SubShape
             {
                 previousPoint.Verb.To = nextPoint.Position;
             }
-            
+
             for (int j = i + 1; j < points.Count; j++)
             {
                 points[j].Index--;
@@ -70,8 +70,8 @@ public class SubShape
         }
 
         points.RemoveAt(i);
-        
-        if(points.Count < 3)
+
+        if (points.Count < 3)
         {
             IsClosed = false;
         }
@@ -128,7 +128,7 @@ public class SubShape
         }
     }
 
-    public void InsertPointAt(VecF point, Verb pointVerb)
+    public int InsertPointAt(VecF point, Verb pointVerb)
     {
         int indexOfVerb = this.points.FirstOrDefault(x => x.Verb == pointVerb)?.Index ?? -1;
         if (indexOfVerb == -1)
@@ -187,6 +187,8 @@ public class SubShape
         {
             this.points[i].Index++;
         }
+
+        return indexOfVerb + 1;
     }
 
     public VecD? GetClosestPointOnPath(VecD point, float maxDistanceInPixels)

--- a/src/PixiEditor/Views/Palettes/PaletteViewer.axaml
+++ b/src/PixiEditor/Views/Palettes/PaletteViewer.axaml
@@ -122,7 +122,6 @@
                                                           DragDrop.AllowDrop="True" Color="{Binding}"
                                                           Height="24" Width="24" CornerRadius="0"
                                                           DropCommand="{Binding ElementName=paletteControl, Path=DropColorCommand}">
-                                >
                                 <Interaction.Behaviors>
                                     <EventTriggerBehavior EventName="PointerReleased">
                                         <InvokeCommandAction

--- a/src/PixiEditor/Views/Rendering/Scene.cs
+++ b/src/PixiEditor/Views/Rendering/Scene.cs
@@ -51,9 +51,6 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
         AvaloniaProperty.Register<Scene, ObservableCollection<Overlay>>(
             nameof(AllOverlays));
 
-    public static readonly StyledProperty<string> CheckerImagePathProperty = AvaloniaProperty.Register<Scene, string>(
-        nameof(CheckerImagePath));
-
     public static readonly StyledProperty<Cursor> DefaultCursorProperty = AvaloniaProperty.Register<Scene, Cursor>(
         nameof(DefaultCursor));
 
@@ -92,6 +89,15 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
         set => SetValue(CustomBackgroundScaleYProperty, value);
     }
 
+    public static readonly StyledProperty<Bitmap> BackgroundBitmapProperty = AvaloniaProperty.Register<Scene, Bitmap>(
+        nameof(BackgroundBitmap));
+
+    public Bitmap BackgroundBitmap
+    {
+        get => GetValue(BackgroundBitmapProperty);
+        set => SetValue(BackgroundBitmapProperty, value);
+    }
+
     public SceneRenderer SceneRenderer
     {
         get => GetValue(SceneRendererProperty);
@@ -102,12 +108,6 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
     {
         get => GetValue(DefaultCursorProperty);
         set => SetValue(DefaultCursorProperty, value);
-    }
-
-    public string CheckerImagePath
-    {
-        get => GetValue(CheckerImagePathProperty);
-        set => SetValue(CheckerImagePathProperty, value);
     }
 
     public ObservableCollection<Overlay> AllOverlays
@@ -139,8 +139,6 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
         get { return (string)GetValue(RenderOutputProperty); }
         set { SetValue(RenderOutputProperty, value); }
     }
-
-    private Bitmap? checkerBitmap;
 
     private Overlay? capturedOverlay;
 
@@ -180,7 +178,6 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
             AutoBackgroundScaleProperty, CustomBackgroundScaleXProperty, CustomBackgroundScaleYProperty);
 
         FadeOutProperty.Changed.AddClassHandler<Scene>(FadeOutChanged);
-        CheckerImagePathProperty.Changed.AddClassHandler<Scene>(CheckerImagePathChanged);
         AllOverlaysProperty.Changed.AddClassHandler<Scene>(ActiveOverlaysChanged);
         DefaultCursorProperty.Changed.AddClassHandler<Scene>(DefaultCursorChanged);
         ChannelsProperty.Changed.AddClassHandler<Scene>(Refresh);
@@ -190,6 +187,7 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
         AutoBackgroundScaleProperty.Changed.AddClassHandler<Scene>(Refresh);
         CustomBackgroundScaleXProperty.Changed.AddClassHandler<Scene>(Refresh);
         CustomBackgroundScaleYProperty.Changed.AddClassHandler<Scene>(Refresh);
+        BackgroundBitmapProperty.Changed.AddClassHandler<Scene>(Refresh);
     }
 
     private static void Refresh(Scene scene, AvaloniaPropertyChangedEventArgs args)
@@ -306,7 +304,7 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
 
     private void DrawCheckerboard(DrawingSurface surface, RectD dirtyBounds)
     {
-        if (checkerBitmap == null) return;
+        if (BackgroundBitmap == null) return;
 
         RectD operationSurfaceRectToRender = new RectD(0, 0, dirtyBounds.Width, dirtyBounds.Height);
         VecD checkerScale = AutoBackgroundScale
@@ -318,7 +316,7 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
         checkerPaint = new Paint
         {
             Shader = Shader.CreateBitmap(
-                checkerBitmap,
+                BackgroundBitmap,
                 TileMode.Repeat, TileMode.Repeat,
                 Matrix3X3.CreateScale((float)checkerScale.X, (float)checkerScale.Y)),
             FilterQuality = FilterQuality.None
@@ -793,18 +791,6 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
         if (e.NewValue is ObservableCollection<Overlay> newOverlays)
         {
             newOverlays.CollectionChanged += scene.OverlayCollectionChanged;
-        }
-    }
-
-    private static void CheckerImagePathChanged(Scene scene, AvaloniaPropertyChangedEventArgs e)
-    {
-        if (e.NewValue is string path)
-        {
-            scene.checkerBitmap = ImagePathToBitmapConverter.LoadDrawingApiBitmapFromRelativePath(path);
-        }
-        else
-        {
-            scene.checkerBitmap = null;
         }
     }
 

--- a/src/PixiEditor/Views/Windows/Settings/SettingsWindow.axaml
+++ b/src/PixiEditor/Views/Windows/Settings/SettingsWindow.axaml
@@ -17,6 +17,7 @@
     xmlns:dialogs="clr-namespace:PixiEditor.Views.Dialogs"
     xmlns:settings="clr-namespace:PixiEditor.Views.Windows.Settings"
     xmlns:localization="clr-namespace:PixiEditor.Extensions.Common.Localization;assembly=PixiEditor.Extensions"
+    xmlns:colorPicker="clr-namespace:ColorPicker;assembly=ColorPicker.AvaloniaUI"
     mc:Ignorable="d"
     x:Class="PixiEditor.Views.Windows.Settings.SettingsWindow"
     Name="window"
@@ -379,6 +380,23 @@
                                                  Size="{Binding SettingsSubViewModel.Scene.CustomBackgroundScaleY, Mode=TwoWay}"
                                                  HorizontalAlignment="Left" />
                             </StackPanel>
+
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <TextBlock ui:Translator.Key="PRIMARY_BG_COLOR" />
+                                <colorPicker:PortableColorPicker Width="40" Height="20" EnableGradientsTab="False"
+                                                                 SelectedColor="{Binding SettingsSubViewModel.Scene.PrimaryBackgroundColor, Mode=TwoWay}" />
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <TextBlock ui:Translator.Key="SECONDARY_BG_COLOR" />
+                                <colorPicker:PortableColorPicker Width="40" Height="20" EnableGradientsTab="False"
+                                                                 SelectedColor="{Binding SettingsSubViewModel.Scene.SecondaryBackgroundColor, Mode=TwoWay}" />
+                            </StackPanel>
+
+                            <Button
+                                Command="{Binding SettingsSubViewModel.Scene.ResetBackgroundCommand}"
+                                d:Content="Reset"
+                                Background="{DynamicResource ThemeAccentBrush}"
+                                ui:Translator.Key="RESET" />
                         </controls:FixedSizeStackPanel>
                     </ScrollViewer>
                 </Grid>

--- a/src/PixiEditor/Views/Windows/Settings/SettingsWindow.axaml
+++ b/src/PixiEditor/Views/Windows/Settings/SettingsWindow.axaml
@@ -192,36 +192,6 @@
                                       IsChecked="{Binding SettingsSubViewModel.Tools.EnableSharedToolbar}"
                                       ui:Translator.Key="ENABLE_SHARED_TOOLBAR" />
 
-                            <TextBlock ui:Translator.Key="AUTOMATIC_UPDATES" Classes="h5" />
-
-                            <CheckBox
-                                VerticalAlignment="Center"
-                                IsEnabled="{Binding Path=ShowUpdateTab}"
-                                IsChecked="{Binding SettingsSubViewModel.Update.CheckUpdatesOnStartup}"
-                                ui:Translator.Key="CHECK_FOR_UPDATES"
-                                Classes="leftOffset" />
-
-                            <StackPanel Orientation="Horizontal" Classes="leftOffset">
-                                <Label Target="updateStreamComboBox" ui:Translator.Key="UPDATE_STREAM"
-                                       VerticalAlignment="Center" />
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
-                                            HorizontalAlignment="Left">
-                                    <ComboBox Width="110"
-                                              Name="updateStreamComboBox"
-                                              VerticalAlignment="Center"
-                                              IsEnabled="{Binding Path=ShowUpdateTab}"
-                                              ItemsSource="{Binding SettingsSubViewModel.Update.UpdateChannels}"
-                                              SelectedValue="{Binding SettingsSubViewModel.Update.UpdateChannelName}" />
-                                    <Image Cursor="Help"
-                                           Source="/Images/Commands/PixiEditor/Links/OpenDocumentation.png"
-                                           VerticalAlignment="Center"
-                                           ToolTip.ShowDelay="0"
-                                           IsVisible="{Binding !ShowUpdateTab}"
-                                           ui:Translator.TooltipKey="UPDATE_CHANNEL_HELP_TOOLTIP" />
-                                    <!-- ToolTipService.InitialShowDelay="0"-->
-                                </StackPanel>
-                            </StackPanel>
-
                             <TextBlock ui:Translator.Key="DEBUG" Classes="h5" />
                             <CheckBox Classes="leftOffset"
                                       IsChecked="{Binding SettingsSubViewModel.General.IsDebugModeEnabled}"
@@ -331,10 +301,84 @@
                         <!--Background="{StaticResource AccentColor}"-->
                         <controls:FixedSizeStackPanel Orientation="Vertical" ChildSize="32"
                                                       VerticalChildrenAlignment="Center" Margin="12">
+                            <TextBlock ui:Translator.Key="AUTOMATIC_UPDATES" Classes="h5" />
+
+                            <CheckBox
+                                VerticalAlignment="Center"
+                                IsEnabled="{Binding Path=ShowUpdateTab}"
+                                IsChecked="{Binding SettingsSubViewModel.Update.CheckUpdatesOnStartup}"
+                                ui:Translator.Key="CHECK_FOR_UPDATES"
+                                Classes="leftOffset" />
+
+                            <StackPanel Orientation="Horizontal" Classes="leftOffset">
+                                <Label Target="updateStreamComboBox" ui:Translator.Key="UPDATE_STREAM"
+                                       VerticalAlignment="Center" />
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                                            HorizontalAlignment="Left">
+                                    <ComboBox Width="110"
+                                              Name="updateStreamComboBox"
+                                              VerticalAlignment="Center"
+                                              IsEnabled="{Binding Path=ShowUpdateTab}"
+                                              ItemsSource="{Binding SettingsSubViewModel.Update.UpdateChannels}"
+                                              SelectedValue="{Binding SettingsSubViewModel.Update.UpdateChannelName}" />
+                                    <Image Cursor="Help"
+                                           Source="/Images/Commands/PixiEditor/Links/OpenDocumentation.png"
+                                           VerticalAlignment="Center"
+                                           ToolTip.ShowDelay="0"
+                                           IsVisible="{Binding !ShowUpdateTab}"
+                                           ui:Translator.TooltipKey="UPDATE_CHANNEL_HELP_TOOLTIP" />
+                                    <!-- ToolTipService.InitialShowDelay="0"-->
+                                </StackPanel>
+                            </StackPanel>
+                        </controls:FixedSizeStackPanel>
+                    </ScrollViewer>
+
+                    <ScrollViewer>
+                        <ScrollViewer.IsVisible>
+                            <Binding Path="CurrentPage" Converter="{converters:IsEqualConverter}">
+                                <Binding.ConverterParameter>
+                                    <sys:Int32>4</sys:Int32>
+                                </Binding.ConverterParameter>
+                            </Binding>
+                        </ScrollViewer.IsVisible>
+                        <!--Background="{StaticResource AccentColor}"-->
+                        <controls:FixedSizeStackPanel Orientation="Vertical" ChildSize="32"
+                                                      VerticalChildrenAlignment="Center" Margin="12">
 
                             <CheckBox Classes="leftOffset" Width="200" HorizontalAlignment="Left"
                                       ui:Translator.Key="OPEN_DIRECTORY_ON_EXPORT"
                                       IsChecked="{Binding SettingsSubViewModel.File.OpenDirectoryOnExport}" />
+                        </controls:FixedSizeStackPanel>
+                    </ScrollViewer>
+                    <ScrollViewer>
+                        <ScrollViewer.IsVisible>
+                            <Binding Path="CurrentPage" Converter="{converters:IsEqualConverter}">
+                                <Binding.ConverterParameter>
+                                    <sys:Int32>5</sys:Int32>
+                                </Binding.ConverterParameter>
+                            </Binding>
+                        </ScrollViewer.IsVisible>
+                        <!--Background="{StaticResource AccentColor}"-->
+                        <controls:FixedSizeStackPanel Orientation="Vertical" ChildSize="32"
+                                                      VerticalChildrenAlignment="Center" Margin="12">
+
+                            <TextBlock ui:Translator.Key="BACKGROUND" Classes="h4" />
+
+                            <CheckBox Classes="leftOffset" Width="200" HorizontalAlignment="Left"
+                                      ui:Translator.Key="AUTO_SCALE_BACKGROUND"
+                                      IsChecked="{Binding SettingsSubViewModel.Scene.AutoScaleBackground}" />
+
+                            <TextBlock ui:Translator.Key="CUSTOM_BACKGROUND_SCALE" Classes="h5" />
+                            <StackPanel Spacing="5" Orientation="Horizontal" Classes="leftOffset">
+                                <Label Content="X" />
+                                <input:SizeInput MinSize="0.5" Decimals="1"
+                                                 Size="{Binding SettingsSubViewModel.Scene.CustomBackgroundScaleX, Mode=TwoWay}"
+                                                 HorizontalAlignment="Left" />
+                                <Label Content="Y" />
+                                <input:SizeInput MinSize="0.5" Decimals="1"
+                                                 Size="{Binding SettingsSubViewModel.Scene.CustomBackgroundScaleY, Mode=TwoWay}"
+                                                 HorizontalAlignment="Left" />
+                            </StackPanel>
                         </controls:FixedSizeStackPanel>
                     </ScrollViewer>
                 </Grid>


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

- [Fixed pixel-art flood fill preserving tolerance](https://github.com/PixiEditor/PixiEditor/commit/f1b7386e45fcb8a84c1503b441088a9ab9b76996)
- [Increased size of vector handles](https://github.com/PixiEditor/PixiEditor/commit/6347e363fea795e3ee7a1de898120bb7938a8579)
- [Create new vector layer on shift instead of doing it automatically on closed shapes](https://github.com/PixiEditor/PixiEditor/commit/72c9861690143e44d4006e1b57ab994798b4144b)
- Fixed tool buttons taking focus, removed focus from layer manager action buttons too
- Fixed drag drop issue that caused layers to drop to the bottom
- Fixed being able to change tool size with pixel perfect option
- Added customization options to checker background

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
