### PR TITLE
Only export translated keys in localization pipeline

### DIFF
--- a/.github/workflows/localization/download-languages.py
+++ b/.github/workflows/localization/download-languages.py
@@ -46,7 +46,8 @@ def fetch_poeditor_language_json(language_code):
         "api_token": API_KEY,
         "id": PROJECT_ID,
         "type": "key_value_json",
-        "language": language_code
+        "language": language_code,
+        "filters": "translated"
     })
     if response.status_code == 200:
         data = response.json()


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

The language sync pipeline will now only export keys that have been translated

There will no longer be a fallback to english

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
