### PR TITLE
adjusted for non-context override expression math

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/MathNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/MathNode.cs
@@ -81,9 +81,9 @@ public class MathNode : Node
             return context.NewFloat1(result);
         }
 
-        var xConst = x.ConstantValue;
-        var yConst = y.ConstantValue;
-        var zConst = z.ConstantValue;
+        var xConst = (double)x.GetConstant();
+        var yConst = (double)y.GetConstant();
+        var zConst = (double)z.GetConstant();
         
         var constValue = Mode.Value switch
         {


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

Fixed a case where color is put into math node, and MathNode didn't take overriden expression constant into consideration

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
