### PR TITLE
Added custom render output sizes

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Interfaces/SceneObjectRenderContext.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Interfaces/SceneObjectRenderContext.cs
@@ -13,7 +13,7 @@ public class SceneObjectRenderContext : RenderContext
     public RenderOutputProperty TargetPropertyOutput { get; }
 
     public SceneObjectRenderContext(RenderOutputProperty targetPropertyOutput, DrawingSurface surface, RectD localBounds, KeyFrameTime frameTime,
-        ChunkResolution chunkResolution, VecI docSize, bool renderSurfaceIsScene, ColorSpace processingColorSpace, double opacity) : base(surface, frameTime, chunkResolution, docSize, processingColorSpace, opacity)
+        ChunkResolution chunkResolution, VecI renderOutputSize, VecI documentSize, bool renderSurfaceIsScene, ColorSpace processingColorSpace, double opacity) : base(surface, frameTime, chunkResolution, renderOutputSize, documentSize, processingColorSpace, opacity)
     {
         TargetPropertyOutput = targetPropertyOutput;
         LocalBounds = localBounds;

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/CreateImageNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/CreateImageNode.cs
@@ -72,7 +72,7 @@ public class CreateImageNode : Node, IPreviewRenderable
         int saved = surface.DrawingSurface.Canvas.Save();
 
         RenderContext ctx = new RenderContext(surface.DrawingSurface, context.FrameTime, context.ChunkResolution,
-            context.DocumentSize, context.ProcessingColorSpace);
+            context.RenderOutputSize, context.DocumentSize, context.ProcessingColorSpace);
 
         surface.DrawingSurface.Canvas.SetMatrix(surface.DrawingSurface.Canvas.TotalMatrix.Concat(ContentMatrix.Value));
 

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/DocumentInfoNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/DocumentInfoNode.cs
@@ -9,16 +9,24 @@ public class DocumentInfoNode : Node
     public OutputProperty<VecI> Size { get; }
     public OutputProperty<VecD> Center { get; }
 
+    public OutputProperty<VecI> RenderOutputSize { get; }
+    public OutputProperty<VecI> RenderOutputCenter { get; }
+
     public DocumentInfoNode()
     {
         Size = CreateOutput("Size", "SIZE", new VecI(0, 0));
         Center = CreateOutput("Center", "CENTER", new VecD(0, 0));
+        RenderOutputSize = CreateOutput("RenderOutputSize", "RENDER_OUTPUT_SIZE", new VecI(0, 0));
+        RenderOutputCenter = CreateOutput("RenderOutputCenter", "RENDER_OUTPUT_CENTER", new VecI(0, 0));
     }
 
     protected override void OnExecute(RenderContext context)
     {
         Size.Value = context.DocumentSize;
         Center.Value = new VecD(context.DocumentSize.X / 2.0, context.DocumentSize.Y / 2.0);
+
+        RenderOutputSize.Value = context.RenderOutputSize;
+        RenderOutputCenter.Value = new VecI(context.RenderOutputSize.X / 2, context.RenderOutputSize.Y / 2);
     }
 
     public override Node CreateCopy()

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Effects/OutlineNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Effects/OutlineNode.cs
@@ -52,7 +52,7 @@ public class OutlineNode : RenderNode, IRenderInput
     protected override void OnExecute(RenderContext context)
     {
         base.OnExecute(context);
-        lastDocumentSize = context.DocumentSize;
+        lastDocumentSize = context.RenderOutputSize;
 
         Kernel finalKernel = Type.Value switch
         {

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/FolderNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/FolderNode.cs
@@ -39,7 +39,7 @@ public class FolderNode : StructureNode, IReadOnlyFolderNode, IClipSource
     protected override void OnExecute(RenderContext context)
     {
         base.OnExecute(context);
-        documentSize = context.DocumentSize;
+        documentSize = context.RenderOutputSize;
     }
 
     public override void Render(SceneObjectRenderContext sceneContext)

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/LayerNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/LayerNode.cs
@@ -44,7 +44,7 @@ public abstract class LayerNode : StructureNode, IReadOnlyLayerNode, IClipSource
                 blendPaint.BlendMode = RenderContext.GetDrawingBlendMode(BlendMode.Value);
             }
 
-            if (AllowHighDpiRendering || renderOnto.DeviceClipBounds.Size == context.DocumentSize)
+            if (AllowHighDpiRendering || renderOnto.DeviceClipBounds.Size == context.RenderOutputSize)
             {
                 DrawLayerInScene(context, renderOnto, useFilters);
             }
@@ -56,7 +56,7 @@ public abstract class LayerNode : StructureNode, IReadOnlyLayerNode, IClipSource
                     BlendMode = Drawie.Backend.Core.Surfaces.BlendMode.SrcOver
                 };
 
-                var tempSurface = TryInitWorkingSurface(context.DocumentSize, context.ChunkResolution,
+                var tempSurface = TryInitWorkingSurface(context.RenderOutputSize, context.ChunkResolution,
                     context.ProcessingColorSpace, 22);
 
                 DrawLayerOnTexture(context, tempSurface.DrawingSurface, context.ChunkResolution, useFilters, targetPaint);
@@ -70,7 +70,7 @@ public abstract class LayerNode : StructureNode, IReadOnlyLayerNode, IClipSource
 
         VecI size = AllowHighDpiRendering
             ? renderOnto.DeviceClipBounds.Size + renderOnto.DeviceClipBounds.Pos
-            : context.DocumentSize;
+            : context.RenderOutputSize;
         int saved = renderOnto.Canvas.Save();
 
         var adjustedResolution = AllowHighDpiRendering ? ChunkResolution.Full : context.ChunkResolution;

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/OutputNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/OutputNode.cs
@@ -32,10 +32,10 @@ public class OutputNode : Node, IRenderInput, IPreviewRenderable
     {
         if (!string.IsNullOrEmpty(context.TargetOutput)) return;
 
-        lastDocumentSize = context.DocumentSize;
+        lastDocumentSize = context.RenderOutputSize;
 
         int saved = context.RenderSurface.Canvas.Save();
-        context.RenderSurface.Canvas.ClipRect(new RectD(0, 0, context.DocumentSize.X, context.DocumentSize.Y));
+        context.RenderSurface.Canvas.ClipRect(new RectD(0, 0, context.RenderOutputSize.X, context.RenderOutputSize.Y));
         Input.Value?.Paint(context, context.RenderSurface);
 
         context.RenderSurface.Canvas.RestoreToCount(saved);

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/RenderNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/RenderNode.cs
@@ -39,18 +39,18 @@ public abstract class RenderNode : Node, IPreviewRenderable, IHighDpiRenderNode
             }
         }
 
-        lastDocumentSize = context.DocumentSize;
+        lastDocumentSize = context.RenderOutputSize;
     }
 
     protected virtual void Paint(RenderContext context, DrawingSurface surface)
     {
         DrawingSurface target = surface;
         bool useIntermediate = !AllowHighDpiRendering
-                               && context.DocumentSize is { X: > 0, Y: > 0 }
-                               && surface.DeviceClipBounds.Size != context.DocumentSize;
+                               && context.RenderOutputSize is { X: > 0, Y: > 0 }
+                               && surface.DeviceClipBounds.Size != context.RenderOutputSize;
         if (useIntermediate)
         {
-            Texture intermediate = textureCache.RequestTexture(-6451, context.DocumentSize, context.ProcessingColorSpace);
+            Texture intermediate = textureCache.RequestTexture(-6451, context.RenderOutputSize, context.ProcessingColorSpace);
             target = intermediate.DrawingSurface;
         }
 

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/ShaderNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/ShaderNode.cs
@@ -48,7 +48,7 @@ public class ShaderNode : RenderNode, IRenderInput, ICustomShaderNode
     {
         base.OnExecute(context);
 
-        lastDocumentSize = context.DocumentSize;
+        lastDocumentSize = context.RenderOutputSize;
 
         if (lastShaderCode != ShaderCode.Value)
         {
@@ -88,7 +88,7 @@ public class ShaderNode : RenderNode, IRenderInput, ICustomShaderNode
         Uniforms uniforms;
         uniforms = new Uniforms();
 
-        uniforms.Add("iResolution", new Uniform("iResolution", (VecD)context.DocumentSize));
+        uniforms.Add("iResolution", new Uniform("iResolution", (VecD)context.RenderOutputSize));
         uniforms.Add("iNormalizedTime", new Uniform("iNormalizedTime", (float)context.FrameTime.NormalizedTime));
         uniforms.Add("iFrame", new Uniform("iFrame", context.FrameTime.Frame));
 
@@ -101,7 +101,7 @@ public class ShaderNode : RenderNode, IRenderInput, ICustomShaderNode
             return uniforms;
         }
 
-        Texture texture = RequestTexture(50, context.DocumentSize, context.ProcessingColorSpace);
+        Texture texture = RequestTexture(50, context.RenderOutputSize, context.ProcessingColorSpace);
         Background.Value.Paint(context, texture.DrawingSurface);
 
         var snapshot = texture.DrawingSurface.Snapshot();
@@ -128,17 +128,17 @@ public class ShaderNode : RenderNode, IRenderInput, ICustomShaderNode
         {
             if (ColorSpace.Value == ColorSpaceType.Srgb && !context.ProcessingColorSpace.IsSrgb)
             {
-                targetSurface = RequestTexture(51, context.DocumentSize,
+                targetSurface = RequestTexture(51, context.RenderOutputSize,
                     Drawie.Backend.Core.Surfaces.ImageData.ColorSpace.CreateSrgb()).DrawingSurface;
             }
             else if (ColorSpace.Value == ColorSpaceType.LinearSrgb && context.ProcessingColorSpace.IsSrgb)
             {
-                targetSurface = RequestTexture(51, context.DocumentSize,
+                targetSurface = RequestTexture(51, context.RenderOutputSize,
                     Drawie.Backend.Core.Surfaces.ImageData.ColorSpace.CreateSrgbLinear()).DrawingSurface;
             }
         }
 
-        targetSurface.Canvas.DrawRect(0, 0, context.DocumentSize.X, context.DocumentSize.Y, paint);
+        targetSurface.Canvas.DrawRect(0, 0, context.RenderOutputSize.X, context.RenderOutputSize.Y, paint);
 
         if (targetSurface != surface)
         {

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/DistributePointsNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/DistributePointsNode.cs
@@ -22,7 +22,7 @@ public class DistributePointsNode : ShapeNode<PointsVectorData>
 
     protected override PointsVectorData? GetShapeData(RenderContext context)
     {
-        return GetPointsRandomly(context.DocumentSize);
+        return GetPointsRandomly(context.RenderOutputSize);
     }
 
     private PointsVectorData GetPointsRandomly(VecI size)

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/StructureNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/StructureNode.cs
@@ -182,7 +182,7 @@ public abstract class StructureNode : RenderNode, IReadOnlyStructureNode, IRende
         RectD localBounds = new RectD(0, 0, sceneSize.X, sceneSize.Y);
 
         SceneObjectRenderContext renderObjectContext = new SceneObjectRenderContext(output, renderTarget, localBounds,
-            context.FrameTime, context.ChunkResolution, context.DocumentSize, renderTarget == context.RenderSurface,
+            context.FrameTime, context.ChunkResolution, context.RenderOutputSize, context.DocumentSize, renderTarget == context.RenderSurface,
             context.ProcessingColorSpace,
             context.Opacity);
         renderObjectContext.FullRerender = context.FullRerender;

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/TileNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/TileNode.cs
@@ -62,7 +62,7 @@ public class TileNode : RenderNode
         if (paint == null)
             return;
 
-        surface.Canvas.DrawRect(0, 0, context.DocumentSize.X, context.DocumentSize.Y, paint);
+        surface.Canvas.DrawRect(0, 0, context.RenderOutputSize.X, context.RenderOutputSize.Y, paint);
     }
 
     public override Node CreateCopy()

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Workspace/CustomOutputNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Workspace/CustomOutputNode.cs
@@ -40,14 +40,14 @@ public class CustomOutputNode : Node, IRenderInput, IPreviewRenderable
         if (context.TargetOutput == OutputName.Value)
         {
             VecI targetSize = Size.Value.ShortestAxis <= 0
-                ? context.DocumentSize
+                ? context.RenderOutputSize
                 : Size.Value;
 
             lastDocumentSize = targetSize;
 
             DrawingSurface targetSurface = context.RenderSurface;
 
-            if(context.DocumentSize != targetSize)
+            if(context.RenderOutputSize != targetSize)
             {
                 targetSurface = textureCache.RequestTexture(0, targetSize, context.ProcessingColorSpace).DrawingSurface;
             }
@@ -56,7 +56,7 @@ public class CustomOutputNode : Node, IRenderInput, IPreviewRenderable
             targetSurface.Canvas.ClipRect(new RectD(0, 0, targetSize.X, targetSize.Y));
 
             RenderContext outputContext = new RenderContext(context.RenderSurface, context.FrameTime, context.ChunkResolution,
-                targetSize, context.ProcessingColorSpace, context.Opacity) { TargetOutput = OutputName.Value, };
+                targetSize, context.DocumentSize, context.ProcessingColorSpace, context.Opacity) { TargetOutput = OutputName.Value, };
 
             Input.Value?.Paint(outputContext, targetSurface);
 

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Workspace/CustomOutputNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Workspace/CustomOutputNode.cs
@@ -10,21 +10,24 @@ public class CustomOutputNode : Node, IRenderInput, IPreviewRenderable
 {
     public const string OutputNamePropertyName = "OutputName";
     public const string IsDefaultExportPropertyName = "IsDefaultExport";
-    public const string ExportSizePropertyName = "ExportSize";
+    public const string SizePropertyName = "Size";
     public RenderInputProperty Input { get; }
     public InputProperty<string> OutputName { get; }
     public InputProperty<bool> IsDefaultExport { get; }
-    public InputProperty<VecI> ExportSize { get; }
+    public InputProperty<VecI> Size { get; }
 
     private VecI? lastDocumentSize;
+
+    private TextureCache textureCache = new TextureCache();
+
     public CustomOutputNode()
     {
         Input = new RenderInputProperty(this, OutputNode.InputPropertyName, "BACKGROUND", null);
         AddInputProperty(Input);
-        
+
         OutputName = CreateInput(OutputNamePropertyName, "OUTPUT_NAME", "");
         IsDefaultExport = CreateInput(IsDefaultExportPropertyName, "IS_DEFAULT_EXPORT", false);
-        ExportSize = CreateInput(ExportSizePropertyName, "EXPORT_SIZE", VecI.Zero);
+        Size = CreateInput(SizePropertyName, "SIZE", VecI.Zero);
     }
 
     public override Node CreateCopy()
@@ -36,25 +39,46 @@ public class CustomOutputNode : Node, IRenderInput, IPreviewRenderable
     {
         if (context.TargetOutput == OutputName.Value)
         {
-            lastDocumentSize = context.DocumentSize;
+            VecI targetSize = Size.Value.ShortestAxis <= 0
+                ? context.DocumentSize
+                : Size.Value;
 
-            int saved = context.RenderSurface.Canvas.Save();
-            context.RenderSurface.Canvas.ClipRect(new RectD(0, 0, context.DocumentSize.X, context.DocumentSize.Y));
-            Input.Value?.Paint(context, context.RenderSurface);
+            lastDocumentSize = targetSize;
 
-            context.RenderSurface.Canvas.RestoreToCount(saved);
+            DrawingSurface targetSurface = context.RenderSurface;
+
+            if(context.DocumentSize != targetSize)
+            {
+                targetSurface = textureCache.RequestTexture(0, targetSize, context.ProcessingColorSpace).DrawingSurface;
+            }
+
+            int saved = targetSurface.Canvas.Save();
+            targetSurface.Canvas.ClipRect(new RectD(0, 0, targetSize.X, targetSize.Y));
+
+            RenderContext outputContext = new RenderContext(context.RenderSurface, context.FrameTime, context.ChunkResolution,
+                targetSize, context.ProcessingColorSpace, context.Opacity) { TargetOutput = OutputName.Value, };
+
+            Input.Value?.Paint(outputContext, targetSurface);
+
+            targetSurface.Canvas.RestoreToCount(saved);
+
+            if (targetSurface != context.RenderSurface)
+            {
+                context.RenderSurface.Canvas.DrawSurface(targetSurface, 0, 0);
+            }
         }
     }
 
     RenderInputProperty IRenderInput.Background => Input;
+
     public RectD? GetPreviewBounds(int frame, string elementToRenderName = "")
     {
         if (lastDocumentSize == null)
         {
             return null;
         }
-        
-        return new RectD(0, 0, lastDocumentSize.Value.X, lastDocumentSize.Value.Y); 
+
+        return new RectD(0, 0, lastDocumentSize.Value.X, lastDocumentSize.Value.Y);
     }
 
     public bool RenderPreview(DrawingSurface renderOn, RenderContext context, string elementToRenderName)
@@ -63,12 +87,12 @@ public class CustomOutputNode : Node, IRenderInput, IPreviewRenderable
         {
             return false;
         }
-        
+
         int saved = renderOn.Canvas.Save();
         Input.Value.Paint(context, renderOn);
-        
+
         renderOn.Canvas.RestoreToCount(saved);
-        
+
         return true;
     }
 }

--- a/src/PixiEditor.ChangeableDocument/Changes/NodeGraph/EvaluateGraph_Change.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/NodeGraph/EvaluateGraph_Change.cs
@@ -32,7 +32,7 @@ internal class EvaluateGraph_Change : Change
 
         using Texture renderTexture = Texture.ForProcessing(target.Size, target.ProcessingColorSpace);
         RenderContext context =
-            new(renderTexture.DrawingSurface, frameTime, ChunkResolution.Full, target.Size,
+            new(renderTexture.DrawingSurface, frameTime, ChunkResolution.Full, target.Size, target.Size,
                 target.ProcessingColorSpace) { FullRerender = true };
         foreach (var nodeToEvaluate in queue)
         {

--- a/src/PixiEditor.ChangeableDocument/Rendering/RenderContext.cs
+++ b/src/PixiEditor.ChangeableDocument/Rendering/RenderContext.cs
@@ -13,8 +13,9 @@ public class RenderContext
 
     public KeyFrameTime FrameTime { get; }
     public ChunkResolution ChunkResolution { get; }
+    public VecI RenderOutputSize { get; set; }
+
     public VecI DocumentSize { get; set; }
-    
     public DrawingSurface RenderSurface { get; set; }
     public bool FullRerender { get; set; } = false;
     
@@ -23,14 +24,15 @@ public class RenderContext
 
 
     public RenderContext(DrawingSurface renderSurface, KeyFrameTime frameTime, ChunkResolution chunkResolution,
-        VecI docSize, ColorSpace processingColorSpace, double opacity = 1) 
+        VecI renderOutputSize, VecI documentSize, ColorSpace processingColorSpace, double opacity = 1)
     {
         RenderSurface = renderSurface;
         FrameTime = frameTime;
         ChunkResolution = chunkResolution;
-        DocumentSize = docSize;
+        RenderOutputSize = renderOutputSize;
         Opacity = opacity;
         ProcessingColorSpace = processingColorSpace;
+        DocumentSize = documentSize;
     }
 
     public static DrawingApiBlendMode GetDrawingBlendMode(BlendMode blendMode)

--- a/src/PixiEditor/Data/Localization/Languages/en.json
+++ b/src/PixiEditor/Data/Localization/Languages/en.json
@@ -1045,5 +1045,6 @@
   "EXPORT_ZONE_NODE": "Export Zone",
   "IS_DEFAULT_EXPORT": "Is Default Export",
   "EXPORT_OUTPUT": "Export Output",
-  "EXPORT_SIZE": "Export Size"
+  "RENDER_OUTPUT_SIZE": "Render Output Size",
+  "RENDER_OUTPUT_CENTER": "Render Output Center",
 }

--- a/src/PixiEditor/Data/Localization/Languages/en.json
+++ b/src/PixiEditor/Data/Localization/Languages/en.json
@@ -1046,5 +1046,5 @@
   "IS_DEFAULT_EXPORT": "Is Default Export",
   "EXPORT_OUTPUT": "Export Output",
   "RENDER_OUTPUT_SIZE": "Render Output Size",
-  "RENDER_OUTPUT_CENTER": "Render Output Center",
+  "RENDER_OUTPUT_CENTER": "Render Output Center"
 }

--- a/src/PixiEditor/Models/Handlers/INodeGraphHandler.cs
+++ b/src/PixiEditor/Models/Handlers/INodeGraphHandler.cs
@@ -21,5 +21,5 @@ internal interface INodeGraphHandler
    public void RemoveConnection(Guid nodeId, string property);
    public void RemoveConnections(Guid nodeId);
    public void UpdateAvailableRenderOutputs();
-   public void GetComputedPropertyValue(INodePropertyHandler property);
+   public void RequestUpdateComputedPropertyValue(INodePropertyHandler property);
 }

--- a/src/PixiEditor/Models/Handlers/INodeHandler.cs
+++ b/src/PixiEditor/Models/Handlers/INodeHandler.cs
@@ -31,4 +31,6 @@ public interface INodeHandler : INotifyPropertyChanged, IDisposable
     public void TraverseForwards(Func<INodeHandler, INodeHandler, bool> func);
     public void TraverseForwards(Func<INodeHandler, INodeHandler, INodePropertyHandler, bool> func);
     public void TraverseForwards(Func<INodeHandler, INodeHandler, INodePropertyHandler, INodePropertyHandler, bool> func);
+    public IReadOnlyDictionary<string, INodePropertyHandler> InputPropertyMap { get; }
+    public IReadOnlyDictionary<string, INodePropertyHandler> OutputPropertyMap { get; }
 }

--- a/src/PixiEditor/Models/Rendering/PreviewPainter.cs
+++ b/src/PixiEditor/Models/Rendering/PreviewPainter.cs
@@ -154,7 +154,7 @@ public class PreviewPainter : IDisposable
 
             renderTexture.DrawingSurface.Canvas.SetMatrix(matrix ?? Matrix3X3.Identity);
 
-            RenderContext context = new(renderTexture.DrawingSurface, FrameTime, ChunkResolution.Full, DocumentSize,
+            RenderContext context = new(renderTexture.DrawingSurface, FrameTime, ChunkResolution.Full, DocumentSize, DocumentSize,
                 ProcessingColorSpace);
 
             dirtyTextures.Remove(texture);

--- a/src/PixiEditor/Models/Rendering/SceneRenderer.cs
+++ b/src/PixiEditor/Models/Rendering/SceneRenderer.cs
@@ -74,9 +74,10 @@ internal class SceneRenderer : IDisposable
         Texture? renderTexture = null;
         bool restoreCanvas = false;
 
-        if (RenderInDocumentSize())
+        VecI finalSize = SolveRenderOutputSize(targetOutput, finalGraph, Document.Size);
+        if (RenderInOutputSize(finalGraph))
         {
-            renderTexture = Texture.ForProcessing(Document.Size, Document.ProcessingColorSpace);
+            renderTexture = Texture.ForProcessing(finalSize, Document.ProcessingColorSpace);
             renderTarget = renderTexture.DrawingSurface;
         }
         else
@@ -93,7 +94,6 @@ internal class SceneRenderer : IDisposable
             restoreCanvas = true;
         }
 
-        VecI finalSize = SolveRenderOutputSize(targetOutput, finalGraph, Document.Size);
         RenderContext context = new(renderTarget, DocumentViewModel.AnimationHandler.ActiveFrameTime,
             resolution, finalSize, Document.Size, Document.ProcessingColorSpace);
         context.TargetOutput = targetOutput;
@@ -136,9 +136,9 @@ internal class SceneRenderer : IDisposable
         return finalSize;
     }
 
-    private bool RenderInDocumentSize()
+    private bool RenderInOutputSize(IReadOnlyNodeGraph finalGraph)
     {
-        return !HighResRendering || !HighDpiRenderNodePresent(Document.NodeGraph);
+        return !HighResRendering || !HighDpiRenderNodePresent(finalGraph);
     }
 
     private bool ShouldRerender(DrawingSurface target, ChunkResolution resolution, string? targetOutput,
@@ -162,7 +162,7 @@ internal class SceneRenderer : IDisposable
             return true;
         }
 
-        bool renderInDocumentSize = RenderInDocumentSize();
+        bool renderInDocumentSize = RenderInOutputSize(finalGraph);
         VecI compareSize = renderInDocumentSize ? Document.Size : target.DeviceClipBounds.Size;
 
         if (cachedTexture.DrawingSurface.DeviceClipBounds.Size != compareSize)

--- a/src/PixiEditor/Models/Rendering/SceneRenderer.cs
+++ b/src/PixiEditor/Models/Rendering/SceneRenderer.cs
@@ -93,9 +93,9 @@ internal class SceneRenderer : IDisposable
             restoreCanvas = true;
         }
 
-        VecI finalSize = SolveDocSize(targetOutput, finalGraph);
+        VecI finalSize = SolveRenderOutputSize(targetOutput, finalGraph, Document.Size);
         RenderContext context = new(renderTarget, DocumentViewModel.AnimationHandler.ActiveFrameTime,
-            resolution, finalSize, Document.ProcessingColorSpace);
+            resolution, finalSize, Document.Size, Document.ProcessingColorSpace);
         context.TargetOutput = targetOutput;
         finalGraph.Execute(context);
 
@@ -112,9 +112,9 @@ internal class SceneRenderer : IDisposable
         return renderTexture;
     }
 
-    private VecI SolveDocSize(string? targetOutput, IReadOnlyNodeGraph finalGraph)
+    private static VecI SolveRenderOutputSize(string? targetOutput, IReadOnlyNodeGraph finalGraph, VecI documentSize)
     {
-        VecI finalSize = Document.Size;
+        VecI finalSize = documentSize;
         if (targetOutput != null)
         {
             var outputNode = finalGraph.AllNodes.FirstOrDefault(n =>
@@ -129,7 +129,7 @@ internal class SceneRenderer : IDisposable
             }
             else
             {
-                finalSize = Document.Size;
+                finalSize = documentSize;
             }
         }
 
@@ -250,6 +250,7 @@ internal class SceneRenderer : IDisposable
         double alphaFalloffMultiplier = 1.0 / animationData.OnionFrames;
 
         var finalGraph = RenderingUtils.SolveFinalNodeGraph(targetOutput, Document);
+        var renderOutputSize = SolveRenderOutputSize(targetOutput, finalGraph, Document.Size);
 
         // Render previous frames'
         for (int i = 1; i <= animationData.OnionFrames; i++)
@@ -262,7 +263,7 @@ internal class SceneRenderer : IDisposable
 
             double finalOpacity = onionOpacity * alphaFalloffMultiplier * (animationData.OnionFrames - i + 1);
 
-            RenderContext onionContext = new(target, frame, resolution, Document.Size, Document.ProcessingColorSpace,
+            RenderContext onionContext = new(target, frame, resolution, renderOutputSize, Document.Size, Document.ProcessingColorSpace,
                 finalOpacity);
             onionContext.TargetOutput = targetOutput;
             finalGraph.Execute(onionContext);
@@ -278,7 +279,7 @@ internal class SceneRenderer : IDisposable
             }
 
             double finalOpacity = onionOpacity * alphaFalloffMultiplier * (animationData.OnionFrames - i + 1);
-            RenderContext onionContext = new(target, frame, resolution, Document.Size, Document.ProcessingColorSpace,
+            RenderContext onionContext = new(target, frame, resolution, renderOutputSize, Document.Size, Document.ProcessingColorSpace,
                 finalOpacity);
             onionContext.TargetOutput = targetOutput;
             finalGraph.Execute(onionContext);

--- a/src/PixiEditor/ViewModels/Document/DocumentViewModel.cs
+++ b/src/PixiEditor/ViewModels/Document/DocumentViewModel.cs
@@ -602,7 +602,7 @@ internal partial class DocumentViewModel : PixiObservableObject, IDocument
 
             Internals.ActionAccumulator.AddActions(
                 new GetComputedPropertyValue_Action(node.Id, CustomOutputNode.OutputNamePropertyName, true),
-                new GetComputedPropertyValue_Action(node.Id, CustomOutputNode.ExportSizePropertyName, true));
+                new GetComputedPropertyValue_Action(node.Id, CustomOutputNode.SizePropertyName, true));
         }
 
         block.ExecuteQueuedActions();
@@ -628,7 +628,7 @@ internal partial class DocumentViewModel : PixiObservableObject, IDocument
             }
 
             VecI originalSize =
-                exportZone.Inputs.FirstOrDefault(x => x.PropertyName == CustomOutputNode.ExportSizePropertyName)
+                exportZone.Inputs.FirstOrDefault(x => x.PropertyName == CustomOutputNode.SizePropertyName)
                     ?.ComputedValue as VecI? ?? SizeBindable;
             if (originalSize.ShortestAxis <= 0)
             {
@@ -663,7 +663,7 @@ internal partial class DocumentViewModel : PixiObservableObject, IDocument
             Internals.ActionAccumulator.AddActions(
                 new GetComputedPropertyValue_Action(node.Id, CustomOutputNode.OutputNamePropertyName, true),
                 new GetComputedPropertyValue_Action(node.Id, CustomOutputNode.IsDefaultExportPropertyName, true),
-                new GetComputedPropertyValue_Action(node.Id, CustomOutputNode.ExportSizePropertyName, true));
+                new GetComputedPropertyValue_Action(node.Id, CustomOutputNode.SizePropertyName, true));
         }
 
         block.ExecuteQueuedActions();
@@ -684,7 +684,7 @@ internal partial class DocumentViewModel : PixiObservableObject, IDocument
             return SizeBindable;
 
         var exportSize =
-            exportNode.Inputs.FirstOrDefault(x => x.PropertyName == CustomOutputNode.ExportSizePropertyName);
+            exportNode.Inputs.FirstOrDefault(x => x.PropertyName == CustomOutputNode.SizePropertyName);
 
         if (exportSize is null)
             return SizeBindable;

--- a/src/PixiEditor/ViewModels/Document/NodeGraphViewModel.cs
+++ b/src/PixiEditor/ViewModels/Document/NodeGraphViewModel.cs
@@ -27,6 +27,8 @@ internal class NodeGraphViewModel : ViewModelBase, INodeGraphHandler, IDisposabl
     public StructureTree StructureTree { get; } = new();
     public INodeHandler? OutputNode { get; private set; }
 
+    public Dictionary<string, INodeHandler> CustomRenderOutputs { get; } = new();
+
     private DocumentInternalParts Internals { get; }
 
     public NodeGraphViewModel(DocumentViewModel documentViewModel, DocumentInternalParts internals)
@@ -115,7 +117,7 @@ internal class NodeGraphViewModel : ViewModelBase, INodeGraphHandler, IDisposabl
             connection.OutputProperty.ConnectedInputs.Remove(connection.InputProperty);
             Connections.Remove(connection);
         }
-        
+
         var node = AllNodes.FirstOrDefault(x => x.Id == nodeId);
         if (node != null)
         {
@@ -224,9 +226,25 @@ internal class NodeGraphViewModel : ViewModelBase, INodeGraphHandler, IDisposabl
         Internals.ActionAccumulator.AddFinishedActions(new UpdatePropertyValue_Action(node.Id, property, value));
     }
 
-    public void GetComputedPropertyValue(INodePropertyHandler property)
+    public void RequestUpdateComputedPropertyValue(INodePropertyHandler property)
     {
-        Internals.ActionAccumulator.AddFinishedActions(new GetComputedPropertyValue_Action(property.Node.Id, property.PropertyName, property.IsInput));
+        Internals.ActionAccumulator.AddActions(
+            new GetComputedPropertyValue_Action(property.Node.Id, property.PropertyName, property.IsInput));
+    }
+
+    public T GetComputedPropertyValue<T>(INodePropertyHandler property)
+    {
+        var node = Internals.Tracker.Document.NodeGraph.AllNodes.FirstOrDefault(x => x.Id == property.Node.Id);
+        if (property.IsInput)
+        {
+            var prop = node.GetInputProperty(property.PropertyName);
+            if (prop == null) return default;
+            return prop.Value is T value ? value : default;
+        }
+
+        var output = node.GetOutputProperty(property.PropertyName);
+        if (output == null) return default;
+        return output.Value is T outputValue ? outputValue : default;
     }
 
     public void EndChangeNodePosition()
@@ -273,7 +291,7 @@ internal class NodeGraphViewModel : ViewModelBase, INodeGraphHandler, IDisposabl
 
     public void RemoveNodes(Guid[] selectedNodes)
     {
-        List<IAction> actions = new(); 
+        List<IAction> actions = new();
 
         for (int i = 0; i < selectedNodes.Length; i++)
         {
@@ -331,10 +349,10 @@ internal class NodeGraphViewModel : ViewModelBase, INodeGraphHandler, IDisposabl
 
         Internals.ActionAccumulator.AddFinishedActions(action);
     }
-    
+
     public void UpdateAvailableRenderOutputs()
     {
-        List<string> outputs = new();
+        Dictionary<string, INodeHandler> outputs = new();
         foreach (var node in AllNodes)
         {
             if (node.InternalName == typeof(CustomOutputNode).GetCustomAttribute<NodeInfoAttribute>().UniqueName)
@@ -344,40 +362,45 @@ internal class NodeGraphViewModel : ViewModelBase, INodeGraphHandler, IDisposabl
 
                 if (nameInput is { Value: string name } && !string.IsNullOrEmpty(name))
                 {
-                    if(outputs.Contains(name)) continue;
-                    
-                    outputs.Add(name);
+                    outputs[name] = node;
                 }
             }
             else if (node.InternalName == typeof(OutputNode).GetCustomAttribute<NodeInfoAttribute>().UniqueName)
             {
-                outputs.Insert(0, "DEFAULT");
+                outputs["DEFAULT"] = node;
             }
         }
-        
+
         RemoveExcessiveRenderOutputs(outputs);
         AddMissingRenderOutputs(outputs);
     }
 
-    private void RemoveExcessiveRenderOutputs(List<string> outputs)
+    private void RemoveExcessiveRenderOutputs(Dictionary<string, INodeHandler> outputs)
     {
         for (int i = AvailableRenderOutputs.Count - 1; i >= 0; i--)
         {
-            if (!outputs.Contains(AvailableRenderOutputs[i]))
+            if (!outputs.ContainsKey(AvailableRenderOutputs[i]))
             {
                 AvailableRenderOutputs.RemoveAt(i);
             }
+
+            if (CustomRenderOutputs.ContainsKey(AvailableRenderOutputs[i]))
+            {
+                CustomRenderOutputs.Remove(AvailableRenderOutputs[i]);
+            }
         }
     }
-    
-    private void AddMissingRenderOutputs(List<string> outputs)
+
+    private void AddMissingRenderOutputs(Dictionary<string, INodeHandler> outputs)
     {
         foreach (var output in outputs)
         {
-            if (!AvailableRenderOutputs.Contains(output))
+            if (!AvailableRenderOutputs.Contains(output.Key))
             {
-                AvailableRenderOutputs.Add(output);
+                AvailableRenderOutputs.Add(output.Key);
             }
+
+            CustomRenderOutputs[output.Key] = output.Value;
         }
     }
 

--- a/src/PixiEditor/ViewModels/Document/NodeGraphViewModel.cs
+++ b/src/PixiEditor/ViewModels/Document/NodeGraphViewModel.cs
@@ -379,15 +379,13 @@ internal class NodeGraphViewModel : ViewModelBase, INodeGraphHandler, IDisposabl
     {
         for (int i = AvailableRenderOutputs.Count - 1; i >= 0; i--)
         {
-            if (!outputs.ContainsKey(AvailableRenderOutputs[i]))
+            var outputName = AvailableRenderOutputs[i];
+            if (!outputs.ContainsKey(outputName))
             {
                 AvailableRenderOutputs.RemoveAt(i);
             }
 
-            if (CustomRenderOutputs.ContainsKey(AvailableRenderOutputs[i]))
-            {
-                CustomRenderOutputs.Remove(AvailableRenderOutputs[i]);
-            }
+            CustomRenderOutputs.Remove(outputName);
         }
     }
 

--- a/src/PixiEditor/ViewModels/SubViewModels/NodeGraphManagerViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/NodeGraphManagerViewModel.cs
@@ -94,6 +94,6 @@ internal class NodeGraphManagerViewModel : SubViewModel<ViewModelMain>
     [Command.Internal("PixiEditor.NodeGraph.GetComputedPropertyValue")]
     public void GetComputedPropertyValue(INodePropertyHandler property)
     {
-        Owner.DocumentManagerSubViewModel.ActiveDocument?.NodeGraph.GetComputedPropertyValue(property);
+        Owner.DocumentManagerSubViewModel.ActiveDocument?.NodeGraph.RequestUpdateComputedPropertyValue(property);
     }
 }

--- a/src/PixiEditor/Views/Main/ViewportControls/ViewportOverlays.cs
+++ b/src/PixiEditor/Views/Main/ViewportControls/ViewportOverlays.cs
@@ -132,11 +132,6 @@ internal class ViewportOverlays
         Binding isVisBinding = new() { Source = Viewport, Path = "GridLinesVisible", Mode = BindingMode.OneWay };
         gridLinesOverlay.Bind(Visual.IsVisibleProperty, isVisBinding);
 
-        Binding binding = new() { Source = Viewport, Path = "Document.Width", Mode = BindingMode.OneWay };
-        gridLinesOverlay.Bind(GridLinesOverlay.PixelWidthProperty, binding);
-        binding = new Binding { Source = Viewport, Path = "Document.Height", Mode = BindingMode.OneWay };
-        gridLinesOverlay.Bind(GridLinesOverlay.PixelHeightProperty, binding);
-
         Binding xBinding = new() { Source = Viewport, Path = "GridLinesXSize", Mode = BindingMode.OneWay };
         gridLinesOverlay.Bind(GridLinesOverlay.GridXSizeProperty, xBinding);
         Binding yBinding = new() { Source = Viewport, Path = "GridLinesYSize", Mode = BindingMode.OneWay };
@@ -177,7 +172,6 @@ internal class ViewportOverlays
         {
             Source = Viewport, Path = "Document.AnySymmetryAxisEnabledBindable", Mode = BindingMode.OneWay
         };
-        Binding sizeBinding = new() { Source = Viewport, Path = "Document.SizeBindable", Mode = BindingMode.OneWay };
         Binding isHitTestVisibleBinding = new()
         {
             Source = Viewport,
@@ -203,7 +197,6 @@ internal class ViewportOverlays
         };
 
         symmetryOverlay.Bind(Visual.IsVisibleProperty, isVisibleBinding);
-        symmetryOverlay.Bind(SymmetryOverlay.SizeProperty, sizeBinding);
         symmetryOverlay.Bind(InputElement.IsHitTestVisibleProperty, isHitTestVisibleBinding);
         symmetryOverlay.Bind(SymmetryOverlay.HorizontalAxisVisibleProperty, horizontalAxisVisibleBinding);
         symmetryOverlay.Bind(SymmetryOverlay.VerticalAxisVisibleProperty, verticalAxisVisibleBinding);

--- a/src/PixiEditor/Views/Overlays/GridLinesOverlay.cs
+++ b/src/PixiEditor/Views/Overlays/GridLinesOverlay.cs
@@ -18,24 +18,6 @@ public class GridLinesOverlay : Overlay
     public static readonly StyledProperty<double> GridYSizeProperty = AvaloniaProperty.Register<GridLinesOverlay, double>(
         nameof(GridYSize));
 
-    public static readonly StyledProperty<int> PixelWidthProperty = AvaloniaProperty.Register<GridLinesOverlay, int>(
-        nameof(PixelWidth));
-
-    public static readonly StyledProperty<int> PixelHeightProperty = AvaloniaProperty.Register<GridLinesOverlay, int>(
-        nameof(PixelHeight));
-
-    public int PixelHeight
-    {
-        get => GetValue(PixelHeightProperty);
-        set => SetValue(PixelHeightProperty, value);
-    }
-
-    public int PixelWidth
-    {
-        get => GetValue(PixelWidthProperty);
-        set => SetValue(PixelWidthProperty, value);
-    }
-
     public double GridXSize
     {
         get => GetValue(GridXSizeProperty);
@@ -74,8 +56,8 @@ public class GridLinesOverlay : Overlay
     {
         // Draw lines in vertical and horizontal directions, size should be relative to the scale
 
-        double width = PixelWidth;
-        double height = PixelHeight;
+        double width = canvasBounds.Width;
+        double height = canvasBounds.Height;
 
         double columnWidth = GridXSize;
         double rowHeight = GridYSize;

--- a/src/PixiEditor/Views/Rendering/Scene.cs
+++ b/src/PixiEditor/Views/Rendering/Scene.cs
@@ -28,8 +28,10 @@ using PixiEditor.Models.DocumentModels;
 using PixiEditor.Models.Rendering;
 using Drawie.Numerics;
 using Drawie.Skia;
+using PixiEditor.ChangeableDocument.Changeables.Graph.Nodes.Workspace;
 using PixiEditor.Extensions.Common.Localization;
 using PixiEditor.ViewModels.Document;
+using PixiEditor.ViewModels.Document.Nodes.Workspace;
 using PixiEditor.Views.Overlays;
 using PixiEditor.Views.Overlays.Pointers;
 using PixiEditor.Views.Visuals;
@@ -74,8 +76,9 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
         set => SetValue(AutoBackgroundScaleProperty, value);
     }
 
-    public static readonly StyledProperty<double> CustomBackgroundScaleXProperty = AvaloniaProperty.Register<Scene, double>(
-        nameof(CustomBackgroundScaleX));
+    public static readonly StyledProperty<double> CustomBackgroundScaleXProperty =
+        AvaloniaProperty.Register<Scene, double>(
+            nameof(CustomBackgroundScaleX));
 
     public double CustomBackgroundScaleX
     {
@@ -83,8 +86,9 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
         set => SetValue(CustomBackgroundScaleXProperty, value);
     }
 
-    public static readonly StyledProperty<double> CustomBackgroundScaleYProperty = AvaloniaProperty.Register<Scene, double>(
-        nameof(CustomBackgroundScaleY));
+    public static readonly StyledProperty<double> CustomBackgroundScaleYProperty =
+        AvaloniaProperty.Register<Scene, double>(
+            nameof(CustomBackgroundScaleY));
 
     public double CustomBackgroundScaleY
     {
@@ -290,7 +294,9 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
 
         renderTexture.Canvas.SetMatrix(matrix.ToSKMatrix().ToMatrix3X3());
 
-        RectD dirtyBounds = new RectD(0, 0, Document.Width, Document.Height);
+        VecI outputSize = FindOutputSize();
+
+        RectD dirtyBounds = new RectD(0, 0, outputSize.X, outputSize.Y);
         RenderScene(dirtyBounds);
 
         renderTexture.Canvas.Restore();
@@ -298,26 +304,23 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
 
     private void RenderScene(RectD bounds)
     {
+        var renderOutput = RenderOutput == "DEFAULT" ? null : RenderOutput;
         DrawCheckerboard(renderTexture.DrawingSurface, bounds);
         DrawOverlays(renderTexture.DrawingSurface, bounds, OverlayRenderSorting.Background);
         try
         {
-            SceneRenderer.RenderScene(renderTexture.DrawingSurface, CalculateResolution(),
-                RenderOutput == "DEFAULT" ? null : RenderOutput);
+            SceneRenderer.RenderScene(renderTexture.DrawingSurface, CalculateResolution(), renderOutput);
         }
         catch (Exception e)
         {
             renderTexture.DrawingSurface.Canvas.Clear();
-            using Paint paint = new Paint
-            {
-                Color = Colors.White,
-                IsAntiAliased = true
-            };
+            using Paint paint = new Paint { Color = Colors.White, IsAntiAliased = true };
 
             using Font defaultSizedFont = Font.CreateDefault();
             defaultSizedFont.Size = 24;
 
-            renderTexture.DrawingSurface.Canvas.DrawText(new LocalizedString("ERROR_GRAPH"), renderTexture.Size / 2f, TextAlign.Center, defaultSizedFont, paint);
+            renderTexture.DrawingSurface.Canvas.DrawText(new LocalizedString("ERROR_GRAPH"), renderTexture.Size / 2f,
+                TextAlign.Center, defaultSizedFont, paint);
         }
 
         DrawOverlays(renderTexture.DrawingSurface, bounds, OverlayRenderSorting.Foreground);
@@ -383,6 +386,26 @@ internal class Scene : Zoombox.Zoombox, ICustomHitTest
 
             e.Handled = args.Handled;
         }
+    }
+
+    private VecI FindOutputSize()
+    {
+        VecI outputSize = Document.SizeBindable;
+
+        if (!string.IsNullOrEmpty(RenderOutput))
+        {
+            if (Document.NodeGraph.CustomRenderOutputs.TryGetValue(RenderOutput, out var node))
+            {
+                var prop = node?.Inputs.FirstOrDefault(x => x.PropertyName == CustomOutputNode.SizePropertyName);
+                if (prop != null)
+                {
+                    VecI size = Document.NodeGraph.GetComputedPropertyValue<VecI>(prop);
+                    outputSize = size;
+                }
+            }
+        }
+
+        return outputSize;
     }
 
     protected override void OnPointerMoved(PointerEventArgs e)

--- a/tests/PixiEditor.Tests/BlendingTests.cs
+++ b/tests/PixiEditor.Tests/BlendingTests.cs
@@ -58,7 +58,7 @@ public class BlendingTests : PixiEditorTest
         secondImageLayer.BlendMode.NonOverridenValue = blendMode;
 
         Surface output = Surface.ForProcessing(VecI.One, ColorSpace.CreateSrgbLinear());
-        graph.Execute(new RenderContext(output.DrawingSurface, 0, ChunkResolution.Full, VecI.One, ColorSpace.CreateSrgbLinear(), 1));
+        graph.Execute(new RenderContext(output.DrawingSurface, 0, ChunkResolution.Full, VecI.One, VecI.One, ColorSpace.CreateSrgbLinear(), 1));
 
         Color result = output.GetSrgbPixel(VecI.Zero);
         Assert.Equal(expectedColor, result.ToRgbHex());


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

It is now possible to specify custom render output size and renderer will use it instead of document size.

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
