### PR TITLE
Fix passing null to string in InvalidFileTypeException

### DIFF
--- a/src/PixiEditor/ViewModels/SubViewModels/FileViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/FileViewModel.cs
@@ -383,7 +383,8 @@ internal class FileViewModel : SubViewModel<ViewModelMain>
 
         AddRecentlyOpened(path);
 
-        var fileType = SupportedFilesHelper.ParseImageFormat(Path.GetExtension(path));
+        var fileExtension = Path.GetExtension(path);
+        var fileType = SupportedFilesHelper.ParseImageFormat(fileExtension);
 
         if (fileType != null)
         {
@@ -393,7 +394,7 @@ internal class FileViewModel : SubViewModel<ViewModelMain>
         else
         {
             CrashHelper.SendExceptionInfo(new InvalidFileTypeException(default,
-                $"Invalid file type '{fileType}'"));
+                $"Invalid file type '{fileExtension}'"));
         }
 
         return doc;


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

At the moment, OpenRegularImage throws a `PixiEditor.Exceptions.InvalidFileTypeException: Invalid file type ''` because `fileType` is always null after the null check

```
        var fileType = SupportedFilesHelper.ParseImageFormat(Path.GetExtension(path));

        if (fileType != null)
        {
            var fileSize = new FileInfo(path).Length;
            Analytics.SendOpenFile(fileType, fileSize, doc.SizeBindable);
        }
        else
        {
            CrashHelper.SendExceptionInfo(new InvalidFileTypeException(default,
                $"Invalid file type '{fileType}'"));
        }
```

The PR fixes it by passing the file extension from `Path.GetExtension(path)` instead

 ## If possible, show examples of usage

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
