### PR TITLE
Rectangle node

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/RectangleNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/RectangleNode.cs
@@ -1,0 +1,35 @@
+﻿using PixiEditor.ChangeableDocument.Changeables.Graph.Nodes.Shapes.Data;
+using PixiEditor.ChangeableDocument.Rendering;
+using Drawie.Backend.Core.ColorsImpl;
+using Drawie.Backend.Core.ColorsImpl.Paintables;
+using Drawie.Numerics;
+
+namespace PixiEditor.ChangeableDocument.Changeables.Graph.Nodes.Shapes;
+
+[NodeInfo("Rectangle")]
+public class RectangleNode : ShapeNode<RectangleVectorData>
+{
+    public InputProperty<VecD> Center { get; }
+    public InputProperty<VecD> Size { get; }
+    public InputProperty<Paintable> StrokeColor { get; }
+    public InputProperty<Paintable> FillColor { get; }
+    public InputProperty<double> StrokeWidth { get; }
+
+    public RectangleNode()
+    {
+        Center = CreateInput<VecD>("Position", "POSITION", VecI.Zero);
+        Size = CreateInput<VecD>("Size", "SIZE", new VecD(32, 32)).WithRules(
+            v => v.Min(new VecD(0)));
+        StrokeColor = CreateInput<Paintable>("StrokeColor", "STROKE_COLOR", new Color(0, 0, 0, 255));
+        FillColor = CreateInput<Paintable>("FillColor", "FILL_COLOR", new Color(0, 0, 0, 255));
+        StrokeWidth = CreateInput<double>("StrokeWidth", "STROKE_WIDTH", 1);
+    }
+
+    protected override RectangleVectorData? GetShapeData(RenderContext context)
+    {
+        return new RectangleVectorData(Center.Value, Size.Value)
+            { Stroke = StrokeColor.Value, FillPaintable = FillColor.Value, StrokeWidth = (float)StrokeWidth.Value };
+    }
+
+    public override Node CreateCopy() => new RectangleNode();
+}

--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/RectangleNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/Shapes/RectangleNode.cs
@@ -11,6 +11,7 @@ public class RectangleNode : ShapeNode<RectangleVectorData>
 {
     public InputProperty<VecD> Center { get; }
     public InputProperty<VecD> Size { get; }
+    public InputProperty<double> CornerRadius { get; }
     public InputProperty<Paintable> StrokeColor { get; }
     public InputProperty<Paintable> FillColor { get; }
     public InputProperty<double> StrokeWidth { get; }
@@ -20,6 +21,7 @@ public class RectangleNode : ShapeNode<RectangleVectorData>
         Center = CreateInput<VecD>("Position", "POSITION", VecI.Zero);
         Size = CreateInput<VecD>("Size", "SIZE", new VecD(32, 32)).WithRules(
             v => v.Min(new VecD(0)));
+        CornerRadius = CreateInput<double>("CornerRadius", "RADIUS", 0);
         StrokeColor = CreateInput<Paintable>("StrokeColor", "STROKE_COLOR", new Color(0, 0, 0, 255));
         FillColor = CreateInput<Paintable>("FillColor", "FILL_COLOR", new Color(0, 0, 0, 255));
         StrokeWidth = CreateInput<double>("StrokeWidth", "STROKE_WIDTH", 1);
@@ -28,7 +30,7 @@ public class RectangleNode : ShapeNode<RectangleVectorData>
     protected override RectangleVectorData? GetShapeData(RenderContext context)
     {
         return new RectangleVectorData(Center.Value, Size.Value)
-            { Stroke = StrokeColor.Value, FillPaintable = FillColor.Value, StrokeWidth = (float)StrokeWidth.Value };
+            { CornerRadius = CornerRadius.Value, Stroke = StrokeColor.Value, FillPaintable = FillColor.Value, StrokeWidth = (float)StrokeWidth.Value };
     }
 
     public override Node CreateCopy() => new RectangleNode();

--- a/src/PixiEditor.UI.Common/Accents/Base.axaml
+++ b/src/PixiEditor.UI.Common/Accents/Base.axaml
@@ -60,6 +60,7 @@
             <Color x:Key="IntSocketColor">#4C64B1</Color>
             <Color x:Key="StringSocketColor">#C9E4C6</Color>
             <Color x:Key="EllipseDataSocketColor">#a473a5</Color>
+            <Color x:Key="RectangleDataSocketColor">#825e8a</Color>
             <Color x:Key="PointsDataSocketColor">#e1d0e1</Color>
             <Color x:Key="TextDataSocketColor">#f2f2f2</Color>
             <Color x:Key="Matrix3X3SocketColor">#ffea4f</Color>
@@ -174,6 +175,7 @@
             <ConicGradientBrush x:Key="ShapeVectorDataSocketBrush"
                                 GradientStops="{StaticResource ShapeDataSocketGradient}" />
             <SolidColorBrush x:Key="EllipseVectorDataSocketBrush" Color="{StaticResource EllipseDataSocketColor}" />
+            <SolidColorBrush x:Key="RectangleVectorDataSocketBrush" Color="{StaticResource RectangleDataSocketColor}" />
             <SolidColorBrush x:Key="PointsVectorDataSocketBrush" Color="{StaticResource PointsDataSocketColor}" />
             <SolidColorBrush x:Key="TextVectorDataSocketBrush" Color="{StaticResource TextDataSocketColor}" />
 

--- a/src/PixiEditor/Data/Localization/Languages/en.json
+++ b/src/PixiEditor/Data/Localization/Languages/en.json
@@ -647,6 +647,7 @@
   "OUTPUT_NODE": "Output",
   "NOISE_NODE": "Noise",
   "ELLIPSE_NODE": "Ellipse",
+  "RECTANGLE_NODE": "Rectangle",
   "CREATE_IMAGE_NODE": "Create Image",
   "FOLDER_NODE": "Folder",
   "IMAGE_LAYER_NODE": "Image Layer",

--- a/src/PixiEditor/ViewModels/Document/Nodes/Shapes/RectangleNodeViewModel.cs
+++ b/src/PixiEditor/ViewModels/Document/Nodes/Shapes/RectangleNodeViewModel.cs
@@ -1,0 +1,9 @@
+﻿using PixiEditor.ChangeableDocument.Changeables.Graph.Nodes.Shapes;
+using PixiEditor.ViewModels.Nodes;
+
+namespace PixiEditor.ViewModels.Document.Nodes.Shapes;
+
+[NodeViewModel("RECTANGLE_NODE", "SHAPE", PixiPerfectIcons.Square)]
+internal class RectangleNodeViewModel : NodeViewModel<RectangleNode>
+{
+}


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

Added Rectangle node under the Shape category.

 ## If possible, show examples of usage

<img width="1148" height="772" alt="rectangle-node" src="https://github.com/user-attachments/assets/ed4470c8-19b7-46dc-ac1b-152451b74212" />

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
