### PR TITLE
Ability to toggle selection tinting

### DIFF
--- a/src/PixiEditor.Extensions.CommonApi/UserPreferences/Settings/PixiEditor/PixiEditorSettings.cs
+++ b/src/PixiEditor.Extensions.CommonApi/UserPreferences/Settings/PixiEditor/PixiEditorSettings.cs
@@ -28,6 +28,8 @@ public static class PixiEditorSettings
     {
         public static SyncedSetting<bool> EnableSharedToolbar { get; } = SyncedSetting.NonOwned<bool>(PixiEditor);
 
+        public static SyncedSetting<bool> SelectionTintingEnabled { get; } = SyncedSetting.NonOwned(PixiEditor, true);
+
         public static SyncedSetting<RightClickMode> RightClickMode { get; } =
             SyncedSetting.NonOwned<RightClickMode>(PixiEditor);
 

--- a/src/PixiEditor/Data/Localization/Languages/en.json
+++ b/src/PixiEditor/Data/Localization/Languages/en.json
@@ -1116,5 +1116,8 @@
   "DISABLE_PREVIEWS": "Disable Previews",
   "MAX_BILINEAR_CANVAS_SIZE": "Max Bilinear Canvas Size",
   "MAX_BILINEAR_CANVAS_SIZE_DESC": "Maximum canvas size for bilinear filtering. Set to 0 to disable bilinear filtering. Bilinear filtering improves the quality of the canvas, but can cause performance issues on large canvases.",
-  "INVERT_MASK": "Invert mask"
+  "INVERT_MASK": "Invert mask",
+  "TOGGLE_TINTING_SELECTION":  "Toggle selection tinting",
+  "TOGGLE_TINTING_SELECTION_DESCRIPTIVE": "Toggle selection tinting",
+  "TINT_SELECTION": "Selection tinting"
 }

--- a/src/PixiEditor/Models/Handlers/IToolsHandler.cs
+++ b/src/PixiEditor/Models/Handlers/IToolsHandler.cs
@@ -19,6 +19,7 @@ internal interface IToolsHandler : IHandler
     public ICollection<IToolSetHandler> AllToolSets { get; }
     public RightClickMode RightClickMode { get; set; }
     public bool EnableSharedToolbar { get; set; }
+    public bool SelectionTintingEnabled { get; set; }
     public event EventHandler<SelectedToolEventArgs> SelectedToolChanged;
     public void SetupTools(IServiceProvider services, ToolSetsConfig toolSetConfig);
     public void SetupToolsTooltipShortcuts();

--- a/src/PixiEditor/ViewModels/PixiObservableObject.cs
+++ b/src/PixiEditor/ViewModels/PixiObservableObject.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using PixiEditor.Extensions.CommonApi.UserPreferences.Settings;
 using PixiEditor.Models.Commands;
 
 namespace PixiEditor.ViewModels;
@@ -11,4 +12,7 @@ public class PixiObservableObject : ObservableObject
         base.OnPropertyChanged(e);
         CommandController.Current.NotifyPropertyChanged(e.PropertyName);
     }
+
+    protected void SubscribeSettingsValueChanged<T>(Setting<T> settingStore, string propertyName) =>
+        settingStore.ValueChanged += (_, _) => OnPropertyChanged(propertyName);
 }

--- a/src/PixiEditor/ViewModels/SubViewModels/ToolsViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/ToolsViewModel.cs
@@ -63,6 +63,19 @@ internal class ToolsViewModel : SubViewModel<ViewModelMain>, IToolsHandler
         }
     }
 
+    public bool SelectionTintingEnabled
+    {
+        get => PixiEditorSettings.Tools.SelectionTintingEnabled.Value;
+        set
+        {
+            if (SelectionTintingEnabled == value)
+                return;
+
+            PixiEditorSettings.Tools.SelectionTintingEnabled.Value = value;
+            OnPropertyChanged();
+        }
+    }
+
     private Cursor? toolCursor;
 
     public Cursor? ToolCursor
@@ -118,6 +131,7 @@ internal class ToolsViewModel : SubViewModel<ViewModelMain>, IToolsHandler
     {
         owner.DocumentManagerSubViewModel.ActiveDocumentChanged += ActiveDocumentChanged;
         PixiEditorSettings.Tools.PrimaryToolset.ValueChanged += PrimaryToolsetOnValueChanged;
+        SubscribeSettingsValueChanged(PixiEditorSettings.Tools.SelectionTintingEnabled, nameof(SelectionTintingEnabled));
     }
 
     private void PrimaryToolsetOnValueChanged(Setting<string> setting, string? newPrimaryToolset)
@@ -173,6 +187,9 @@ internal class ToolsViewModel : SubViewModel<ViewModelMain>, IToolsHandler
 
         OnPropertyChanged(nameof(NonSelectedToolSets));
     }
+
+    [Command.Basic("PixiEditor.Tools.ToggleSelectionTinting", "TOGGLE_TINTING_SELECTION", "TOGGLE_TINTING_SELECTION_DESCRIPTIVE", AnalyticsTrack = true)]
+    public void ToggleTintSelection() => SelectionTintingEnabled = !SelectionTintingEnabled;
 
     public void SetupToolsTooltipShortcuts()
     {

--- a/src/PixiEditor/ViewModels/UserPreferences/Settings/SceneSettings.cs
+++ b/src/PixiEditor/ViewModels/UserPreferences/Settings/SceneSettings.cs
@@ -3,6 +3,7 @@ using Avalonia.Media;
 using CommunityToolkit.Mvvm.Input;
 using Drawie.Numerics;
 using PixiEditor.Extensions.CommonApi.UserPreferences;
+using PixiEditor.Extensions.CommonApi.UserPreferences.Settings.PixiEditor;
 using PixiEditor.Helpers.Extensions;
 
 namespace PixiEditor.ViewModels.UserPreferences.Settings;
@@ -44,6 +45,12 @@ internal class SceneSettings : SettingsGroup
         set => RaiseAndUpdatePreference(ref _secondaryBackgroundColorHex, value, PreferencesConstants.SecondaryBackgroundColor);
     }
 
+    public bool SelectionTintingEnabled
+    {
+        get => PixiEditorSettings.Tools.SelectionTintingEnabled.Value;
+        set => RaiseAndUpdatePreference(PixiEditorSettings.Tools.SelectionTintingEnabled, value);
+    }
+
     public Color PrimaryBackgroundColor
     {
         get => Color.Parse(PrimaryBackgroundColorHex);
@@ -65,5 +72,7 @@ internal class SceneSettings : SettingsGroup
             PrimaryBackgroundColorHex = PreferencesConstants.PrimaryBackgroundColorDefault;
             SecondaryBackgroundColorHex = PreferencesConstants.SecondaryBackgroundColorDefault;
         });
+        
+        SubscribeValueChanged(PixiEditorSettings.Tools.SelectionTintingEnabled, nameof(SelectionTintingEnabled));
     }
 }

--- a/src/PixiEditor/ViewModels/UserPreferences/SettingsGroup.cs
+++ b/src/PixiEditor/ViewModels/UserPreferences/SettingsGroup.cs
@@ -1,10 +1,11 @@
 ﻿using System.Runtime.CompilerServices;
 using CommunityToolkit.Mvvm.ComponentModel;
 using PixiEditor.Extensions.CommonApi.UserPreferences;
+using PixiEditor.Extensions.CommonApi.UserPreferences.Settings;
 
 namespace PixiEditor.ViewModels.UserPreferences;
 
-internal class SettingsGroup : ObservableObject
+internal class SettingsGroup : PixiObservableObject
 {
     protected static T GetPreference<T>(string name)
     {
@@ -26,5 +27,19 @@ internal class SettingsGroup : ObservableObject
     {
         SetProperty(ref backingStore, value, propertyName: name);
         IPreferences.Current.UpdatePreference(name, value);
+    }
+    
+    protected void RaiseAndUpdatePreference<T>(Setting<T> settingStore, T value, [CallerMemberName] string name = "")
+    {
+        if (EqualityComparer<T>.Default.Equals(settingStore.Value, value))
+            return;
+
+        settingStore.Value = value;
+        OnPropertyChanged(name);
+    }
+
+    protected void SubscribeValueChanged<T>(Setting<T> settingStore, string propertyName)
+    {
+        settingStore.ValueChanged += (_, _) => OnPropertyChanged(propertyName);
     }
 }

--- a/src/PixiEditor/Views/Main/ViewportControls/ViewportOverlays.cs
+++ b/src/PixiEditor/Views/Main/ViewportControls/ViewportOverlays.cs
@@ -155,6 +155,13 @@ internal class ViewportOverlays
             Mode = BindingMode.OneWay
         };
 
+        Binding selectionTintingEnabled = new()
+        {
+            Source = ViewModelMain.Current,
+            Path = "ToolsSubViewModel.SelectionTintingEnabled",
+            Mode = BindingMode.OneWay
+        };
+
         MultiBinding showFillBinding = new()
         {
             Converter = new AllTrueConverter(),
@@ -162,7 +169,8 @@ internal class ViewportOverlays
             Bindings = new List<IBinding>()
             {
                 toolIsSelectionBinding,
-                isTransformingBinding
+                isTransformingBinding,
+                selectionTintingEnabled
             }
         };
 

--- a/src/PixiEditor/Views/Windows/Settings/SettingsWindow.axaml
+++ b/src/PixiEditor/Views/Windows/Settings/SettingsWindow.axaml
@@ -421,6 +421,13 @@
                                 d:Content="Reset"
                                 Background="{DynamicResource ThemeAccentBrush}"
                                 ui:Translator.Key="RESET" />
+                            
+                            <TextBlock ui:Translator.Key="SELECTION" Classes="h5" />
+
+                            <CheckBox Classes="leftOffset" Width="200" HorizontalAlignment="Left"
+                                      ui:Translator.Key="TINT_SELECTION"
+                                      IsChecked="{Binding SettingsSubViewModel.Scene.SelectionTintingEnabled}" />
+
                         </controls:FixedSizeStackPanel>
                     </ScrollViewer>
                     <ScrollViewer>


### PR DESCRIPTION
This PR adds the ability to toggle selection tinting. Tinting can be toggled by

* Using the Check Box in the Settings Window
* Using the "Toggle selection tinting" command

Closes #1090 

## SELECT BELOW TO CONTINUE
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
