### PR TITLE
Improved sampling formula

### DIFF
--- a/src/PixiEditor/Models/Rendering/PreviewPainter.cs
+++ b/src/PixiEditor/Models/Rendering/PreviewPainter.cs
@@ -173,7 +173,7 @@ public class PreviewPainter : IDisposable
             VecI bounds = painterInstance.RequestRenderBounds?.Invoke() ?? VecI.Zero;
 
             ChunkResolution finalResolution = FindResolution(bounds);
-            SamplingOptions samplingOptions = FindSamplingOptions(bounds);
+            SamplingOptions samplingOptions = FindSamplingOptions(matrix);
 
             renderTexture.DrawingSurface.Canvas.SetMatrix(matrix ?? Matrix3X3.Identity);
             renderTexture.DrawingSurface.Canvas.Scale((float)finalResolution.InvertedMultiplier());
@@ -257,10 +257,10 @@ public class PreviewPainter : IDisposable
         return ChunkResolution.Full;
     }
 
-    private SamplingOptions FindSamplingOptions(VecI bounds)
+    private SamplingOptions FindSamplingOptions(Matrix3X3? matrix)
     {
-        var density = DocumentSize.X / (double)bounds.X;
-        return density > 1
+        Matrix3X3 mtx = matrix ?? Matrix3X3.Identity;
+        return mtx.ScaleX < 1f || mtx.ScaleY < 1f
             ? SamplingOptions.Bilinear
             : SamplingOptions.Default;
     }


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

Previously layers were blurry for small layers. Sampling calculation is now based on scale, if matrix is smaller than 1 preview is zoomed out and should be sampled bilinear, but if it's zoomed in (scale > 1) details should be visible (nearest sampling)

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
