### PR TITLE
Fixed resize undo applying one frame to all key frames

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changes/Root/ClipCanvas_Change.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Root/ClipCanvas_Change.cs
@@ -52,9 +52,9 @@ internal class ClipCanvas_Change : ResizeBasedChangeBase
         {
             if (member is ImageLayerNode layer)
             {
-                layer.ForEveryFrame(img =>
+                layer.ForEveryFrame((img, id) =>
                 {
-                    Resize(img, layer.Id, size, -(VecI)newBounds.Pos, deletedChunks);
+                    Resize(img, id, size, -(VecI)newBounds.Pos, deletedChunks);
                 });
             }
             else if (member is ITransformableObject transformableObject)

--- a/src/PixiEditor.ChangeableDocument/Changes/Root/Crop_Change.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Root/Crop_Change.cs
@@ -37,9 +37,9 @@ internal class Crop_Change : ResizeBasedChangeBase
         {
             if (member is ImageLayerNode layer)
             {
-                layer.ForEveryFrame(frame =>
+                layer.ForEveryFrame((frame, id) =>
                 {
-                    Resize(frame, layer.Id, rect.Size, rect.Pos * -1, deletedChunks);
+                    Resize(frame, id, rect.Size, rect.Pos * -1, deletedChunks);
                 });
             }
             if (member.EmbeddedMask is null)

--- a/src/PixiEditor.ChangeableDocument/Changes/Root/ResizeBasedChangeBase.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Root/ResizeBasedChangeBase.cs
@@ -52,10 +52,10 @@ internal abstract class ResizeBasedChangeBase : Change
         {
             if (member is ImageLayerNode layer)
             {
-                layer.ForEveryFrame(img =>
+                layer.ForEveryFrame((img, id) =>
                 {
                     img.EnqueueResize(_originalSize);
-                    foreach (var stored in deletedChunks[layer.Id])
+                    foreach (var stored in deletedChunks[id])
                         stored.ApplyChunksToImage(img);
                     img.CommitChanges();
                 });

--- a/src/PixiEditor.ChangeableDocument/Changes/Root/ResizeCanvas_Change.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Root/ResizeCanvas_Change.cs
@@ -49,9 +49,9 @@ internal class ResizeCanvas_Change : ResizeBasedChangeBase
         {
             if (member is ImageLayerNode layer)
             {
-                layer.ForEveryFrame(img =>
+                layer.ForEveryFrame((img, id) =>
                 {
-                    Resize(img, layer.Id, newSize, offset, deletedChunks);
+                    Resize(img, id, newSize, offset, deletedChunks);
                 });
             }
 

--- a/src/PixiEditor.ChangeableDocument/Changes/Root/ResizeImage_Change.cs
+++ b/src/PixiEditor.ChangeableDocument/Changes/Root/ResizeImage_Change.cs
@@ -91,11 +91,11 @@ internal class ResizeImage_Change : Change
         {
             if (member is ImageLayerNode layer)
             {
-                layer.ForEveryFrame(img =>
+                layer.ForEveryFrame((img, id) =>
                 {
                     ScaleChunkyImage(img);
                     var affected = img.FindAffectedArea();
-                    savedChunks[layer.Id] = new CommittedChunkStorage(img, affected.Chunks);
+                    savedChunks[id] = new CommittedChunkStorage(img, affected.Chunks);
                     img.CommitChanges();
                 });
             }
@@ -127,11 +127,11 @@ internal class ResizeImage_Change : Change
         {
             if (member is ImageLayerNode layer)
             {
-                layer.ForEveryFrame(layerImage =>
+                layer.ForEveryFrame((layerImage, id) =>
                 {
                     layerImage.EnqueueResize(originalSize);
                     layerImage.EnqueueClear();
-                    savedChunks[layer.Id].ApplyChunksToImage(layerImage);
+                    savedChunks[id].ApplyChunksToImage(layerImage);
                     layerImage.CommitChanges();
                 });
             }

--- a/src/PixiEditor/ViewModels/Document/NodeGraphViewModel.cs
+++ b/src/PixiEditor/ViewModels/Document/NodeGraphViewModel.cs
@@ -161,8 +161,10 @@ internal class NodeGraphViewModel : ViewModelBase, INodeGraphHandler, IDisposabl
             if (x is not IPairNodeStartViewModel)
                 return Traverse.Further;
 
-            var zone = startLookup[x];
-            currentlyPartOf.Add(zone);
+            if (startLookup != null && startLookup.TryGetValue(x, out var zone))
+            {
+                currentlyPartOf.Add(zone);
+            }
 
             return Traverse.Further;
         });


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

https://forum.pixieditor.net/t/pressing-the-undo-button-after-resizing-the-canvas-results-in-broken-animations/436

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
