### PR TITLE
Added Accessibility settings and UI Scaling option

### DIFF
--- a/src/PixiEditor/Data/Localization/Languages/en.json
+++ b/src/PixiEditor/Data/Localization/Languages/en.json
@@ -1148,5 +1148,8 @@
   "POSTERIZATION_NODE": "Posterize",
   "LEVELS": "Levels",
   "RGB_POSTERIZATION_MODE": "RGB",
-  "LUMINANCE_POSTERIZATION_MODE": "Luminance"
+  "LUMINANCE_POSTERIZATION_MODE": "Luminance",
+  "ACCESSIBILITY": "Accessibility",
+  "UI_SCALE": "UI Scale",
+  "UI_SCALE_EXEMPTS_SETTINGS": "Setting windows are intentionally not affected by UI Scaling."
 }

--- a/src/PixiEditor/Data/Localization/Languages/it.json
+++ b/src/PixiEditor/Data/Localization/Languages/it.json
@@ -559,5 +559,8 @@
   "USE_SECONDARY_COLOR": "Usa colore secondario",
   "RIGHT_CLICK_MODE": "Modalità tasto destro",
   "ADD_PRIMARY_COLOR_TO_PALETTE": "Aggiungi colore primario alla tavolozza",
-  "ADD_PRIMARY_COLOR_TO_PALETTE_DESCRIPTIVE": "Aggiungi colore primario alla tavolozza corrente"
+  "ADD_PRIMARY_COLOR_TO_PALETTE_DESCRIPTIVE": "Aggiungi colore primario alla tavolozza corrente",
+  "ACCESSIBILITY": "Accessibilità",
+  "UI_SCALE": "Ingrandimento UI",
+  "UI_SCALE_EXEMPTS_SETTINGS": "Le finestre d'impostazione sono intenzionalmente escluse dall'ingrandimento.",
 }

--- a/src/PixiEditor/ViewModels/SettingsWindowViewModel.cs
+++ b/src/PixiEditor/ViewModels/SettingsWindowViewModel.cs
@@ -274,7 +274,8 @@ internal partial class SettingsWindowViewModel : ViewModelBase
             new SettingsPage("UPDATES"),
             new("EXPORT"),
             new SettingsPage("SCENE"),
-            new("PERFORMANCE")
+            new("PERFORMANCE"),
+            new("ACCESSIBILITY"),
         };
 
         ILocalizationProvider.Current.OnLanguageChanged += OnLanguageChanged;

--- a/src/PixiEditor/ViewModels/UserPreferences/Settings/AccessibilitySettings.cs
+++ b/src/PixiEditor/ViewModels/UserPreferences/Settings/AccessibilitySettings.cs
@@ -1,0 +1,19 @@
+﻿namespace PixiEditor.ViewModels.UserPreferences.Settings;
+
+internal class AccessibilitySettings : SettingsGroup
+{
+    
+    private double _uiScaleFactor = GetPreference(nameof(UiScaleFactor), 1.0);
+    
+    public double UiScaleFactor
+    {
+        get => _uiScaleFactor;
+        set
+        {
+            RaiseAndUpdatePreference(ref _uiScaleFactor, value);
+            OnPropertyChanged(nameof(UiScaleFactorPreview));
+        }
+    }
+
+    public string UiScaleFactorPreview => (UiScaleFactor * 100).ToString("F0") + "%";
+}

--- a/src/PixiEditor/ViewModels/UserPreferences/SettingsViewModel.cs
+++ b/src/PixiEditor/ViewModels/UserPreferences/SettingsViewModel.cs
@@ -18,6 +18,8 @@ internal class SettingsViewModel : SubViewModel<SettingsWindowViewModel>
     public SceneSettings Scene { get; set; } = new();
 
     public PerformanceSettings Performance { get; set; } = new();
+    
+    public AccessibilitySettings Accessibility { get; set; } = new();
 
     public SettingsViewModel(SettingsWindowViewModel owner)
         : base(owner)

--- a/src/PixiEditor/Views/MainWindow.axaml
+++ b/src/PixiEditor/Views/MainWindow.axaml
@@ -28,5 +28,8 @@
             </OnPlatform.Linux>
         </OnPlatform> 
     </Window.SystemDecorations>
-    <views1:MainView />
+    
+    <LayoutTransformControl x:Name="PrimaryScaleControl">
+        <views1:MainView />
+    </LayoutTransformControl>
 </Window>

--- a/src/PixiEditor/Views/MainWindow.axaml.cs
+++ b/src/PixiEditor/Views/MainWindow.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
+using Avalonia.Media;
 using Avalonia.OpenGL;
 using Avalonia.Platform;
 using Avalonia.Rendering.Composition;
@@ -132,6 +133,13 @@ internal partial class MainWindow : Window
     {
         base.OnLoaded(e);
         
+        ApplyUiScale();
+        
+        preferences.AddCallback("UiScaleFactor", (_, args) =>
+        {
+            Dispatcher.UIThread.Post(ApplyUiScale);
+        });
+        
         titleBar = this.FindDescendantOfType<MainTitleBar>(true);
         if (System.OperatingSystem.IsLinux())
         {
@@ -141,7 +149,6 @@ internal partial class MainWindow : Window
             AddHandler(PointerPressedEvent, Pressed, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
         }
         
-
         LoadingWindow.Instance?.SafeClose();
         Activate();
         StartupPerformance.ReportToInteractivity();
@@ -215,4 +222,12 @@ internal partial class MainWindow : Window
             CrashHelper.SaveCrashInfo((Exception)e.ExceptionObject, DataContext.DocumentManagerSubViewModel.Documents);
         };
     }
+
+    private void ApplyUiScale()
+    {
+        double scale = preferences.GetPreference("UiScaleFactor", 1.0);
+
+        PrimaryScaleControl.LayoutTransform = new ScaleTransform(scale, scale);
+    }
+    
 }

--- a/src/PixiEditor/Views/Windows/Settings/SettingsWindow.axaml
+++ b/src/PixiEditor/Views/Windows/Settings/SettingsWindow.axaml
@@ -467,6 +467,36 @@
                             </StackPanel>
                         </controls:FixedSizeStackPanel>
                     </ScrollViewer>
+                    <ScrollViewer>
+                        <ScrollViewer.IsVisible>
+                            <Binding Path="CurrentPage" Converter="{converters:IsEqualConverter}">
+                                <Binding.ConverterParameter>
+                                    <sys:Int32>7</sys:Int32>
+                                </Binding.ConverterParameter>
+                            </Binding>
+                        </ScrollViewer.IsVisible>
+
+                        <controls:FixedSizeStackPanel Orientation="Vertical" ChildSize="32"
+                                                      VerticalChildrenAlignment="Center" Margin="12">
+
+                            <TextBlock ui:Translator.Key="UI_SCALE" Classes="h5" />
+
+                            <StackPanel Orientation="Horizontal" Spacing="10" Classes="leftOffset">
+                                <Slider Width="200"
+                                        Minimum="0.5" Maximum="2.5"
+                                        TickFrequency="0.05"
+                                        IsSnapToTickEnabled="True"
+                                        Value="{Binding SettingsSubViewModel.Accessibility.UiScaleFactor, Mode=TwoWay}"/>
+                                
+                                <TextBlock Text="{Binding SettingsSubViewModel.Accessibility.UiScaleFactorPreview}"
+                                           VerticalAlignment="Center"/>
+                                
+                            </StackPanel>
+                            
+                            <TextBlock ui:Translator.Key="UI_SCALE_EXEMPTS_SETTINGS" Classes="leftOffset subtext" />
+
+                        </controls:FixedSizeStackPanel>
+                    </ScrollViewer>
                 </Grid>
             </Border>
         </DockPanel>


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

Added an Accessibility settings category, in which I added a UI Scale slider.

Completes #1107 

 ## If possible, show examples of usage

https://github.com/user-attachments/assets/90e46ded-b7f7-4b49-9bdd-4cbe3cd27ca0

## SELECT BELOW TO CONTINUE
- [x] I wrote tests for my changes (if possible)
- [x] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
