### PR TITLE
Fix crash on dotnet publish by using AppContext.BaseDirectory

### DIFF
--- a/src/PixiEditor/Models/IO/Paths.cs
+++ b/src/PixiEditor/Models/IO/Paths.cs
@@ -8,10 +8,10 @@ public static class Paths
     public static string DataResourceUri { get; } = $"avares://{typeof(Paths).Assembly.GetName().Name}/Data/";
 
     public static string DataFullPath { get; } =
-        Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Data");
+        Path.Combine(AppContext.BaseDirectory, "Data");
 
     public static string InstallDirExtensionPackagesPath { get; } =
-        Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Extensions");
+        Path.Combine(AppContext.BaseDirectory, "Extensions");
 
     public static string LocalExtensionPackagesPath { get; } = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -49,7 +49,7 @@ public static class Paths
         "PixiEditor", "Autosave");
 
     public static string InstallDirectoryPath { get; } =
-        Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) ?? string.Empty;
+        AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
     public static string ParseSpecialPathOrDefault(string path)
     {


### PR DESCRIPTION
Assembly.GetEntryAssembly().Location can return null or empty string in certain publish scenarios (single-file publish, some Linux deployments like aarch64), causing path combination to fail. Replace with AppContext.BaseDirectory which is the recommended way to get the application base directory in .NET Core/.NET and works reliably across all publish configurations.

Fixes [#1145](https://github.com/PixiEditor/PixiEditor/issues/1145)


