### PR TITLE
Fix create image button padding oopsie

### DIFF
--- a/src/PixiEditor/Views/Dialogs/NewFilePopup.axaml
+++ b/src/PixiEditor/Views/Dialogs/NewFilePopup.axaml
@@ -41,14 +41,12 @@
                           x:Name="sizePicker" />
         </StackPanel>
         </Border>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,15,0,15" Spacing="10">
-            <Button DockPanel.Dock="Bottom" Margin="0,15,0,15" VerticalAlignment="Center"
-                    IsDefault="True" ui:Translator.Key="CREATE" x:Name="createButton" Focusable="True"
-                    Command="{Binding Path=DataContext.SetResultAndCloseCommand, ElementName=popup}">
-                <Button.CommandParameter>
-                    <system:Boolean>True</system:Boolean>
-                </Button.CommandParameter>
-            </Button>
-        </StackPanel>
+        <Button DockPanel.Dock="Bottom" Margin="0,15,0,15" HorizontalAlignment="Center"
+                IsDefault="True" ui:Translator.Key="CREATE" x:Name="createButton" Focusable="True"
+                Command="{Binding Path=DataContext.SetResultAndCloseCommand, ElementName=popup}">
+            <Button.CommandParameter>
+                <system:Boolean>True</system:Boolean>
+            </Button.CommandParameter>
+        </Button>
     </StackPanel>
 </dialogs:PixiEditorPopup>


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

<img width="763" height="488" alt="{7B9BC1DA-0DC4-4E4D-BB16-547892BA2CFC}" src="https://github.com/user-attachments/assets/6f2dd59c-4945-461c-a901-838c55575221" />


the padding was increased by accident in #1351
thanks @Equbuxu for pointing it out lol

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [X] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
