### PR TITLE
Opening and svg now will do a better job with positioning nodes

### DIFF
--- a/src/PixiEditor/Models/IO/CustomDocumentFormats/SvgDocumentBuilder.cs
+++ b/src/PixiEditor/Models/IO/CustomDocumentFormats/SvgDocumentBuilder.cs
@@ -15,6 +15,7 @@ using PixiEditor.ChangeableDocument.Changeables.Graph.Nodes.FilterNodes;
 using PixiEditor.ChangeableDocument.Changeables.Graph.Nodes.Shapes.Data;
 using PixiEditor.Helpers;
 using PixiEditor.Models.Dialogs;
+using PixiEditor.Parser;
 using PixiEditor.Parser.Graph;
 using PixiEditor.SVG;
 using PixiEditor.SVG.Elements;
@@ -92,6 +93,13 @@ internal class SvgDocumentBuilder : IDocumentBuilder
                 }
 
                 graph.WithOutputNode(lastId, "Output");
+
+                VecD pos = VecD.Zero;
+                foreach (var node in graph.AllNodes)
+                {
+                    node.Position = new Vector2() { X = (float)pos.X, Y = (float)pos.Y };
+                    pos += new VecD(250, 0);
+                }
             });
 
         if (unknownSize)


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

Opening svg will now lay nodes next to each other, it's not perfect as it might not position filters nicely, but it's already much better than having everything on top of each other. And honestly, most of SVGs are groups and shapes anyway

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
