### PR TITLE
Fixed No Context Exception being thrown from Modify Image Node (Left)

### DIFF
--- a/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/ModifyImageLeftNode.cs
+++ b/src/PixiEditor.ChangeableDocument/Changeables/Graph/Nodes/ModifyImageLeftNode.cs
@@ -36,9 +36,7 @@ public class ModifyImageLeftNode : Node, IPairNode
 
     private Half4 GetColor(FuncContext context)
     {
-        context.ThrowOnMissingContext();
-
-        if (Image.Value == null)
+        if (!context.HasContext || Image.Value == null)
         {
             return new Half4("") { ConstantValue = Colors.Transparent };
         }


### PR DESCRIPTION
It was very annoying since whenever you hovered mouse over the color socket or any connected nodes the program throws an exception so you couldn't connect anything to it

 ## Clearly describe changes, as detailed as possible

the ThrowOnMissingContext call in Left Modify Image Node has been replaced by returning a transparent image instead of throwing an exception.

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [X] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)

https://github.com/user-attachments/assets/a19d9f34-d045-4b6d-a472-7f42245889ab
