### PR TITLE
Changed path of autosave to be in local appdata

### DIFF
--- a/src/PixiEditor/Helpers/AutosaveUtility.cs
+++ b/src/PixiEditor/Helpers/AutosaveUtility.cs
@@ -4,6 +4,8 @@ namespace PixiEditor.Helpers;
 
 internal class AutosaveHelper
 {
+    static string legacyAutosavePath = Path.Join(Path.GetTempPath(), "PixiEditor", "Autosave");
+
     public static Guid? GetAutosaveGuid(string? path)
     {
         if (path is null)
@@ -15,6 +17,13 @@ internal class AutosaveHelper
 
     public static string GetAutosavePath(Guid guid)
     {
-        return Path.Join(Paths.PathToUnsavedFilesFolder, $"autosave-{guid}.pixi");
+
+        string path = Path.Join(Paths.PathToUnsavedFilesFolder, $"autosave-{guid}.pixi");
+        if (!File.Exists(path))
+        {
+            return Path.Join(legacyAutosavePath, $"autosave-{guid}.zip");
+        }
+
+        return path;
     }
 }

--- a/src/PixiEditor/Helpers/AutosaveUtility.cs
+++ b/src/PixiEditor/Helpers/AutosaveUtility.cs
@@ -4,7 +4,7 @@ namespace PixiEditor.Helpers;
 
 internal class AutosaveHelper
 {
-    static string legacyAutosavePath = Path.Join(Path.GetTempPath(), "PixiEditor", "Autosave");
+    static readonly string LegacyAutosavesPath = Path.Join(Path.GetTempPath(), "PixiEditor", "Autosave");
 
     public static Guid? GetAutosaveGuid(string? path)
     {
@@ -19,9 +19,10 @@ internal class AutosaveHelper
     {
 
         string path = Path.Join(Paths.PathToUnsavedFilesFolder, $"autosave-{guid}.pixi");
+        // TODO: This is pretty much temporary, once enough time passes, no check for legacy autosave should be needed.
         if (!File.Exists(path))
         {
-            return Path.Join(legacyAutosavePath, $"autosave-{guid}.zip");
+            return Path.Join(LegacyAutosavesPath, $"autosave-{guid}.pixi");
         }
 
         return path;

--- a/src/PixiEditor/Models/IO/Paths.cs
+++ b/src/PixiEditor/Models/IO/Paths.cs
@@ -50,10 +50,10 @@ public static class Paths
     public static string TempSessionFilesPath { get; }  = Path.Combine(Path.GetTempPath(), "PixiEditor", "SessionCache");
 
     /// <summary>
-    /// Path to %temp%/PixiEditor/Autosave
+    /// Path to %localappdata%/PixiEditor/Autosave
     /// </summary>
     public static string PathToUnsavedFilesFolder { get; } = Path.Join(
-        Path.GetTempPath(),
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "PixiEditor", "Autosave");
 
     public static string InstallDirectoryPath { get; } =


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

Tmp is not a good place for autosaves. It completely doesn't work on flatpak and might behave unexpectedly on some setups. Having them in localappdata solves these problems.

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
