### PR TITLE
Footer Element placement changes and button hover implementation

### DIFF
--- a/src/PixiEditor.UI.Common/Controls/Shelf.axaml
+++ b/src/PixiEditor.UI.Common/Controls/Shelf.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:PixiEditor.UI.Common.Controls">
     <ControlTheme TargetType="controls:Shelf" x:Key="{x:Type controls:Shelf}">
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush1}" />
         <Setter Property="Transitions">
             <Transitions>
                 <TransformOperationsTransition Easing="SineEaseInOut" Property="RenderTransform" Duration="0:0:0.3" />
@@ -10,7 +11,7 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <Border CornerRadius="{DynamicResource ControlCornerRadiusTop}"
-                        Background="{DynamicResource ThemeBackgroundBrush1}">
+                        Background="{TemplateBinding Background}">
                     <DockPanel LastChildFill="True">
                         <CheckBox IsChecked="{TemplateBinding IsOpen, Mode=TwoWay}" Focusable="False" ZIndex="10"
                                   Name="PART_VisibilityCheckbox" Height="16" HorizontalAlignment="Right"

--- a/src/PixiEditor.UI.Common/Fonts/PixiPerfectStyles.axaml
+++ b/src/PixiEditor.UI.Common/Fonts/PixiPerfectStyles.axaml
@@ -40,6 +40,10 @@
         <Setter Property="CornerRadius" Value="6" />
     </Style>
 
+    <Style Selector="Button.pixi-icon[Width=24][Height=24]">
+        <Setter Property="FontSize" Value="18" />
+    </Style>
+
     <Style Selector="ToggleButton.pixi-icon">
         <Setter Property="FontFamily" Value="{DynamicResource PixiPerfectIcons}" />
         <Setter Property="BorderThickness" Value="0" />
@@ -62,6 +66,10 @@
     <Style Selector="ToggleButton.pixi-icon:checked /template/ ContentPresenter">
         <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
         <Setter Property="CornerRadius" Value="6" />
+    </Style>
+
+    <Style Selector="ToggleButton.pixi-icon[Width=24][Height=24]">
+        <Setter Property="FontSize" Value="18" />
     </Style>
 
     <Style Selector="MenuItem.pixi-icon">

--- a/src/PixiEditor.UI.Common/Fonts/PixiPerfectStyles.axaml
+++ b/src/PixiEditor.UI.Common/Fonts/PixiPerfectStyles.axaml
@@ -25,14 +25,19 @@
         <Setter Property="FontFamily" Value="{DynamicResource PixiPerfectIcons}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="FontSize" Value="24" />
+        <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
         <Setter Property="Padding" Value="0" />
+        <Setter Property="Width" Value="32" />
+        <Setter Property="Height" Value="32" />
+        <Setter Property="CornerRadius" Value="6" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="BorderThickness" Value="0" />
     </Style>
 
-    <Style Selector="Button.pixi-icon:pointerover">
-        <Setter Property="Background" Value="Transparent" />
+    <Style Selector="Button.pixi-icon:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+        <Setter Property="CornerRadius" Value="6" />
     </Style>
 
     <Style Selector="ToggleButton.pixi-icon">
@@ -40,13 +45,23 @@
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="FontSize" Value="24" />
+        <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
         <Setter Property="Padding" Value="0" />
+        <Setter Property="Width" Value="32" />
+        <Setter Property="Height" Value="32" />
+        <Setter Property="CornerRadius" Value="6" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 
-    <Style Selector="ToggleButton.pixi-icon:checked">
+    <Style Selector="ToggleButton.pixi-icon:pointerover /template/ ContentPresenter">
         <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+        <Setter Property="CornerRadius" Value="6" />
+    </Style>
+
+    <Style Selector="ToggleButton.pixi-icon:checked /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+        <Setter Property="CornerRadius" Value="6" />
     </Style>
 
     <Style Selector="MenuItem.pixi-icon">

--- a/src/PixiEditor/Styles/PortingWipStyles.axaml
+++ b/src/PixiEditor/Styles/PortingWipStyles.axaml
@@ -54,6 +54,7 @@
         <Setter Property="Content" Value="{DynamicResource icon-play}" />
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{DynamicResource ThemeAccent2Brush}"/>
+        <Setter Property="FontSize" Value="24" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>
@@ -63,7 +64,7 @@
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Width}"
                             Background="{TemplateBinding Background}">
-                        <TextBlock Text="{TemplateBinding Content}" FontSize="{TemplateBinding Width}"
+                        <TextBlock Text="{TemplateBinding Content}" FontSize="{TemplateBinding FontSize}"
                                    HorizontalAlignment="Center" VerticalAlignment="Center"
                                    Classes="pixi-icon" />
                     </Border>
@@ -74,6 +75,10 @@
 
     <Style Selector="ToggleButton.PlayButton:pointerover /template/ Border#PlayButtonBorder">
         <Setter Property="Background" Value="{DynamicResource ThemeAccent2LowBrush}" />
+    </Style>
+
+    <Style Selector="ToggleButton.PlayButton.timeline:pointerover /template/ Border#PlayButtonBorder">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
     </Style>
 
     <Style Selector="ToggleButton.PlayButton:checked">

--- a/src/PixiEditor/Styles/PortingWipStyles.axaml
+++ b/src/PixiEditor/Styles/PortingWipStyles.axaml
@@ -36,7 +36,10 @@
             <Setter.Value>
                 <ControlTemplate>
                     <Border Cursor="Hand" Background="{TemplateBinding Background}">
-                        <TextBlock Text="{TemplateBinding Content}" FontSize="16" Classes="pixi-icon" />
+                        <TextBlock Text="{TemplateBinding Content}"
+                                   Foreground="{TemplateBinding Foreground}"
+                                   FontSize="16"
+                                   Classes="pixi-icon" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
@@ -54,13 +57,23 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Border Cursor="Hand" Background="{TemplateBinding Background}">
+                    <Border Name="PlayButtonBorder"
+                            Cursor="Hand"
+                            CornerRadius="6"
+                            Width="{TemplateBinding Width}"
+                            Height="{TemplateBinding Width}"
+                            Background="{TemplateBinding Background}">
                         <TextBlock Text="{TemplateBinding Content}" FontSize="{TemplateBinding Width}"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"
                                    Classes="pixi-icon" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+
+    <Style Selector="ToggleButton.PlayButton:pointerover /template/ Border#PlayButtonBorder">
+        <Setter Property="Background" Value="{DynamicResource ThemeAccent2LowBrush}" />
     </Style>
 
     <Style Selector="ToggleButton.PlayButton:checked">

--- a/src/PixiEditor/Styles/PortingWipStyles.axaml
+++ b/src/PixiEditor/Styles/PortingWipStyles.axaml
@@ -20,6 +20,43 @@
         <Setter Property="BorderThickness" Value="0"/>
     </Style>
 
+    <Style Selector="Button.OverlayButton:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+        <Setter Property="CornerRadius" Value="6" />
+    </Style>
+
+    <Style Selector="ToggleButton.OverlayButton:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+        <Setter Property="CornerRadius" Value="6" />
+    </Style>
+
+    <Style Selector="ToggleButton.OverlayButton.pixi-icon:checked /template/ ContentPresenter">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{DynamicResource SelectedToolBorderBrush}" />
+        <Setter Property="BorderThickness" Value="2" />
+        <Setter Property="CornerRadius" Value="6" />
+    </Style>
+
+    <Style Selector="ToggleButton.OverlayButton.pixi-icon:checked:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+    </Style>
+
+    <Style Selector="ToggleButton.OverlayToggleButton:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+        <Setter Property="CornerRadius" Value="6" />
+    </Style>
+
+    <Style Selector="ToggleButton.OverlayToggleButton.pixi-icon:checked /template/ ContentPresenter">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{DynamicResource SelectedToolBorderBrush}" />
+        <Setter Property="BorderThickness" Value="2" />
+        <Setter Property="CornerRadius" Value="6" />
+    </Style>
+
+    <Style Selector="ToggleButton.OverlayToggleButton.pixi-icon:checked:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+    </Style>
+
     <Style Selector="Button.ImageButtonStyle">
         <Setter Property="Template">
             <ControlTemplate>

--- a/src/PixiEditor/Styles/Templates/Timeline.axaml
+++ b/src/PixiEditor/Styles/Templates/Timeline.axaml
@@ -106,7 +106,7 @@
                                     ui1:Translator.TooltipKey="STEP_BACK"
                                     Command="{Binding StepBackCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     Content="{DynamicResource icon-step-back}" />
-                            <ToggleButton Margin="0, 5" Width="24" HorizontalAlignment="Center" Classes="PlayButton"
+                            <ToggleButton Width="32" HorizontalAlignment="Center" Classes="PlayButton timeline"
                                           Name="PART_PlayToggle"
                                           IsChecked="{Binding IsPlaying, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}" />
                             <Button Classes="pixi-icon"

--- a/src/PixiEditor/Styles/Templates/Timeline.axaml
+++ b/src/PixiEditor/Styles/Templates/Timeline.axaml
@@ -41,19 +41,23 @@
                                                 Size="{Binding Fps, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}" />
 
                             <Button Classes="pixi-icon" DockPanel.Dock="Right"
-                                    Content="{DynamicResource icon-settings}"
                                     ui1:Translator.TooltipKey="SETTINGS">
-                                <Button.Styles>
-                                    <Style Selector="Button:pointerover">
-                                        <Setter Property="RenderTransform" Value="rotate(45deg)" />
-                                    </Style>
-                                </Button.Styles>
-                                <Button.Transitions>
-                                    <Transitions>
-                                        <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.3"
-                                                                       Easing="SineEaseInOut" />
-                                    </Transitions>
-                                </Button.Transitions>
+                                <TextBlock Classes="pixi-icon"
+                                           Text="{DynamicResource icon-settings}"
+                                           FontSize="24"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <TextBlock.Styles>
+                                        <Style Selector="Button:pointerover TextBlock">
+                                            <Setter Property="RenderTransform" Value="rotate(45deg)" />
+                                        </Style>
+                                    </TextBlock.Styles>
+                                    <TextBlock.Transitions>
+                                        <Transitions>
+                                            <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.3"
+                                                                           Easing="SineEaseInOut" />
+                                        </Transitions>
+                                    </TextBlock.Transitions>
+                                </TextBlock>
                                 <Button.Flyout>
                                     <Flyout Placement="Top">
                                         <Grid>

--- a/src/PixiEditor/Styles/ToolPickerButton.Styles.axaml
+++ b/src/PixiEditor/Styles/ToolPickerButton.Styles.axaml
@@ -4,7 +4,7 @@
         xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <Styles.Resources>
-        <Color x:Key="SelectedToolBorderColor">#fff</Color>
+        <Color x:Key="SelectedToolBorderColor">#888</Color>
         <CornerRadius x:Key="SelectedToolCornerRadius">5</CornerRadius>
         <SolidColorBrush x:Key="SelectedToolBorderBrush" Color="{StaticResource SelectedToolBorderColor}"/>
     </Styles.Resources>

--- a/src/PixiEditor/Views/Auth/UserAvatarToggle.axaml
+++ b/src/PixiEditor/Views/Auth/UserAvatarToggle.axaml
@@ -50,11 +50,17 @@
                 </Style.Animations>
             </Style>
         </Grid.Styles>
-        <Border ClipToBounds="True" IsVisible="{Binding IsLoggedIn}" CornerRadius="25">
-            <Button Name="UserAvatarButton" Padding="0"
-                    BorderThickness="0" Classes="pixi-icon">
+        <Border IsVisible="{Binding IsLoggedIn}">
+            <Button Name="UserAvatarButton" Padding="1"
+                    BorderThickness="0" Classes="pixi-icon"
+                    Width="26" Height="26"
+                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    CornerRadius="6">
                 <Button.Content>
-                    <Image asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}" />
+                    <Border ClipToBounds="True" CornerRadius="12.5" Width="25" Height="25">
+                        <Image asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}" />
+                    </Border>
                 </Button.Content>
                 <Button.Styles>
                     <Style Selector="FlyoutPresenter">
@@ -133,6 +139,12 @@
         </Ellipse>
         <Button IsVisible="{Binding !IsLoggedIn}"
                 Classes="pixi-icon"
+                Width="26" Height="26"
+                HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                CornerRadius="6"
+                FontSize="20"
+                HorizontalContentAlignment="Center"
+                VerticalContentAlignment="Center"
                 Content="{DynamicResource icon-user}"
                 Command="{xaml:Command Name=PixiEditor.Window.OpenAccountWindow}" />
     </Grid>

--- a/src/PixiEditor/Views/Auth/UserAvatarToggle.axaml
+++ b/src/PixiEditor/Views/Auth/UserAvatarToggle.axaml
@@ -51,14 +51,14 @@
             </Style>
         </Grid.Styles>
         <Border IsVisible="{Binding IsLoggedIn}">
-            <Button Name="UserAvatarButton" Padding="1"
+            <Button Name="UserAvatarButton" Padding="3"
                     BorderThickness="0" Classes="pixi-icon"
                     Width="24" Height="24"
                     HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                     CornerRadius="6">
                 <Button.Content>
-                    <Border ClipToBounds="True" CornerRadius="11" Width="22" Height="22">
+                    <Border ClipToBounds="True" CornerRadius="9" Width="18" Height="18">
                         <Image asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}" />
                     </Border>
                 </Button.Content>
@@ -139,7 +139,7 @@
         </Ellipse>
         <Button IsVisible="{Binding !IsLoggedIn}"
                 Classes="pixi-icon"
-                Width="24" Height="24"
+                Width="24" Height="24" FontSize="18"
                 HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                 CornerRadius="6"
                 HorizontalContentAlignment="Center"

--- a/src/PixiEditor/Views/Auth/UserAvatarToggle.axaml
+++ b/src/PixiEditor/Views/Auth/UserAvatarToggle.axaml
@@ -53,12 +53,12 @@
         <Border IsVisible="{Binding IsLoggedIn}">
             <Button Name="UserAvatarButton" Padding="1"
                     BorderThickness="0" Classes="pixi-icon"
-                    Width="26" Height="26"
+                    Width="24" Height="24"
                     HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                     CornerRadius="6">
                 <Button.Content>
-                    <Border ClipToBounds="True" CornerRadius="12.5" Width="25" Height="25">
+                    <Border ClipToBounds="True" CornerRadius="11" Width="22" Height="22">
                         <Image asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}" />
                     </Border>
                 </Button.Content>
@@ -139,10 +139,9 @@
         </Ellipse>
         <Button IsVisible="{Binding !IsLoggedIn}"
                 Classes="pixi-icon"
-                Width="26" Height="26"
+                Width="24" Height="24"
                 HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                 CornerRadius="6"
-                FontSize="20"
                 HorizontalContentAlignment="Center"
                 VerticalContentAlignment="Center"
                 Content="{DynamicResource icon-user}"

--- a/src/PixiEditor/Views/Input/BrushItem.axaml
+++ b/src/PixiEditor/Views/Input/BrushItem.axaml
@@ -44,7 +44,7 @@
                     Command="{Binding ToggleFavorite}"
                     localization:Translator.TooltipKey="ADD_TO_FAVORITES">
                     <Button.Styles>
-                        <Style Selector="Button:pointerover">
+                        <Style Selector="Button:pointerover /template/ ContentPresenter">
                             <Setter Property="Background" Value="Orange" />
                         </Style>
                     </Button.Styles>

--- a/src/PixiEditor/Views/Input/BrushPicker.axaml
+++ b/src/PixiEditor/Views/Input/BrushPicker.axaml
@@ -62,7 +62,6 @@
                                      Text="{Binding $parent[input:BrushPicker].SearchText}">
                                 <TextBox.InnerLeftContent>
                                     <TextBlock Classes="pixi-icon" Text="{DynamicResource icon-search}"
-                                               FontSize="14"
                                                VerticalAlignment="Center"
                                                Margin="0, 0, 5, 0" />
                                 </TextBox.InnerLeftContent>
@@ -96,24 +95,24 @@
                                 </StackPanel.Styles>
                                 <ToggleButton Classes="pixi-icon"
                                               Name="SortButton"
-                                              FontSize="24"
+                                              Width="24" Height="24"
                                               localization:Translator.TooltipKey="SORTING"
                                               Content="{DynamicResource icon-arrow-up-down}" />
                                 <ToggleButton Classes="pixi-icon"
                                               Name="ViewModeListButton"
+                                              Width="24" Height="24"
                                               localization:Translator.TooltipKey="TOGGLE_VIEW_MODE"
                                               IsChecked="{Binding $parent[input:BrushPicker].IsGridView,Mode=TwoWay}" />
                                 <Button Classes="pixi-icon"
                                         Command="{xaml:Command PixiEditor.Brushes.Import}"
-                                        FontSize="24"
+                                        Width="24" Height="24"
                                         localization:Translator.TooltipKey="IMPORT_BRUSH"
                                         Content="{DynamicResource icon-upload}" />
                                 <Button Classes="pixi-icon"
-                                        Width="20"
-                                        FontSize="18"
-                                        Padding="0"
+                                        Width="18" Height="24"
                                         HorizontalContentAlignment="Center"
                                         VerticalContentAlignment="Center"
+                                        FontSize="18"
                                         localization:Translator.TooltipKey="MORE_OPTIONS"
                                         Content="{DynamicResource icon-ellipsis-vertical}">
                                     <Interaction.Behaviors>

--- a/src/PixiEditor/Views/Input/BrushPicker.axaml
+++ b/src/PixiEditor/Views/Input/BrushPicker.axaml
@@ -106,8 +106,11 @@
                                         localization:Translator.TooltipKey="IMPORT_BRUSH"
                                         Content="{DynamicResource icon-upload}" />
                                 <Button Classes="pixi-icon"
-                                        Width="14"
-                                        FontSize="24"
+                                        Width="20"
+                                        FontSize="18"
+                                        Padding="0"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
                                         localization:Translator.TooltipKey="MORE_OPTIONS"
                                         Content="{DynamicResource icon-ellipsis-vertical}">
                                     <Interaction.Behaviors>

--- a/src/PixiEditor/Views/Input/BrushPicker.axaml
+++ b/src/PixiEditor/Views/Input/BrushPicker.axaml
@@ -58,9 +58,12 @@
 
                             <TextBox Watermark="{localization:Translate Key=SEARCH}"
                                      Name="SearchBox"
+                                     VerticalContentAlignment="Center"
                                      Text="{Binding $parent[input:BrushPicker].SearchText}">
                                 <TextBox.InnerLeftContent>
                                     <TextBlock Classes="pixi-icon" Text="{DynamicResource icon-search}"
+                                               FontSize="14"
+                                               VerticalAlignment="Center"
                                                Margin="0, 0, 5, 0" />
                                 </TextBox.InnerLeftContent>
                             </TextBox>

--- a/src/PixiEditor/Views/Layers/LayersManager.axaml
+++ b/src/PixiEditor/Views/Layers/LayersManager.axaml
@@ -33,7 +33,7 @@
                 <Button
                     Command="{xaml:Command PixiEditor.Layer.NewLayer}"
                     DockPanel.Dock="Left"
-                    Height="24" Width="24" Cursor="Hand" uiExt:Translator.TooltipKey="NEW_LAYER"
+                    Height="24" Width="24" FontSize="18" Cursor="Hand" uiExt:Translator.TooltipKey="NEW_LAYER"
                     HorizontalAlignment="Stretch" Margin="0,0,5,0"
                     Classes="pixi-icon"
                     Focusable="False"
@@ -41,7 +41,7 @@
                     FlowDirection="LeftToRight" />
                 <Button
                     Command="{xaml:Command PixiEditor.Layer.NewFolder}"
-                    Height="24" Width="24" uiExt:Translator.TooltipKey="NEW_FOLDER" Cursor="Hand"
+                    Height="24" Width="24" FontSize="18" uiExt:Translator.TooltipKey="NEW_FOLDER" Cursor="Hand"
                     DockPanel.Dock="Left"
                     HorizontalAlignment="Stretch" Margin="0,0,5,0"
                     Classes="pixi-icon"
@@ -49,7 +49,7 @@
                     Content="{DynamicResource icon-folder-plus}"
                     FlowDirection="LeftToRight" />
                 <Button
-                    Command="{xaml:Command PixiEditor.Layer.DeleteAllSelected}" Height="24" Width="24"
+                    Command="{xaml:Command PixiEditor.Layer.DeleteAllSelected}" Height="24" Width="24" FontSize="18"
                     uiExt:Translator.TooltipKey="LAYER_DELETE_ALL_SELECTED"
                     Cursor="Hand"
                     HorizontalAlignment="Stretch" Margin="0,0,5,0"
@@ -59,7 +59,7 @@
                     Content="{DynamicResource icon-trash}"
                     FlowDirection="LeftToRight" />
                 <Button
-                    Command="{xaml:Command PixiEditor.Layer.MergeWithBelow}" Height="24" Width="24"
+                    Command="{xaml:Command PixiEditor.Layer.MergeWithBelow}" Height="24" Width="24" FontSize="18"
                     uiExt:Translator.TooltipKey="MERGE_WITH_BELOW" Cursor="Hand"
                     DockPanel.Dock="Right"
                     HorizontalAlignment="Stretch" Margin="5,0,0,0"
@@ -68,7 +68,7 @@
                     Content="{DynamicResource icon-merge}"
                     FlowDirection="LeftToRight" />
                 <Button
-                    Height="24" Width="24" uiExt:Translator.TooltipKey="CREATE_MASK" Cursor="Hand"
+                    Height="24" Width="24" FontSize="18" uiExt:Translator.TooltipKey="CREATE_MASK" Cursor="Hand"
                     DockPanel.Dock="Right"
                     HorizontalAlignment="Stretch" Margin="5,0,0,0"
                     Classes="pixi-icon"
@@ -77,7 +77,7 @@
                     Command="{xaml:Command PixiEditor.Layer.CreateMask}"
                     FlowDirection="LeftToRight" />
                 <Button
-                    Height="24" Width="24" uiExt:Translator.TooltipKey="LOCK_TRANSPARENCY" Cursor="Hand"
+                    Height="24" Width="24" FontSize="18" uiExt:Translator.TooltipKey="LOCK_TRANSPARENCY" Cursor="Hand"
                     DockPanel.Dock="Right"
                     HorizontalAlignment="Stretch" Margin="5,0,0,0"
                     Classes="pixi-icon"

--- a/src/PixiEditor/Views/Layers/ReferenceLayer.axaml
+++ b/src/PixiEditor/Views/Layers/ReferenceLayer.axaml
@@ -39,16 +39,16 @@
             <controls:Shelf x:Name="referenceShelf"
                             Classes.noRef="{Binding Document.ReferenceLayerViewModel.ReferenceTexture, ElementName=uc, Converter={converters:NullToVisibilityConverter}}"
                             ControlToCollapse="{Binding RelativeSource={RelativeSource AncestorType=UserControl, Mode=FindAncestor}}">
-                <Grid Height="40" x:Name="mainDockPanel">
+                <Grid Height="32" x:Name="mainDockPanel">
                     <Grid x:Name="addRefArea"
                           IsVisible="{Binding Document.ReferenceLayerViewModel.ReferenceTexture, ElementName=uc, Converter={converters:NullToVisibilityConverter}}"
                           ZIndex="5"
                           Cursor="Hand">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock Margin="5 0 5 0" VerticalAlignment="Center" FontSize="24" Text="{DynamicResource icon-add-reference}" Classes="pixi-icon" />
+                            <TextBlock Margin="5 0 5 0" VerticalAlignment="Center" FontSize="18" Text="{DynamicResource icon-add-reference}" Classes="pixi-icon" />
                             <TextBlock IsEnabled="{Binding ElementName=uc, Path=IsEnabled}"
                                        Margin="0 0 5 0" Foreground="{DynamicResource ThemeForegroundBrush}"
-                                       FontSize="15" VerticalAlignment="Center"
+                                       FontSize="14" VerticalAlignment="Center"
                                        ui:Translator.Key="ADD_REFERENCE_LAYER" />
                         </StackPanel>
                         <Interaction.Behaviors>
@@ -59,7 +59,7 @@
                         </Interaction.Behaviors>
                     </Grid>
 
-                    <DockPanel Grid.Row="0" VerticalAlignment="Center" Height="40"
+                    <DockPanel Grid.Row="0" VerticalAlignment="Center" Height="32"
                                IsVisible="{Binding Document.ReferenceLayerViewModel.ReferenceTexture, ElementName=uc, Converter={converters:NotNullToVisibilityConverter}}">
                         <Grid Height="16" Name="layerVisibilityCheckboxGrid" DockPanel.Dock="Left" Margin="10,0,5,0">
                             <CheckBox
@@ -74,7 +74,7 @@
                                 Classes="pixi-icon"
                                 ToolTip.Tip="{Binding Document.ReferenceLayerViewModel.IsTopMost, ElementName=uc, Converter={converters:BoolToValueConverter FalseValue='localized:PUT_REFERENCE_LAYER_ABOVE', TrueValue='localized:PUT_REFERENCE_LAYER_BELOW'}}"
                                 RenderOptions.BitmapInterpolationMode="HighQuality"
-                                Width="24" Height="24" HorizontalAlignment="Right"/>
+                                Width="24" Height="24" FontSize="18" HorizontalAlignment="Right"/>
                         <Border
                             HorizontalAlignment="Left" DockPanel.Dock="Left"
                             Width="30" Height="30"
@@ -92,7 +92,7 @@
                                 RenderOptions.BitmapInterpolationMode="HighQuality"
                                 Margin="3,0,5,0"
                                 Content="{DynamicResource icon-trash}"
-                                Width="24" Height="24" HorizontalAlignment="Right"/>
+                                Width="24" Height="24" FontSize="18" HorizontalAlignment="Right"/>
                         <Button Cursor="Hand" DockPanel.Dock="Right"
                                 Command="{cmds:Command PixiEditor.Layer.ResetReferenceLayerPosition}"
                                 Classes="pixi-icon"
@@ -100,17 +100,17 @@
                                 Margin="2, 0, 0, 0"
                                 ui:Translator.TooltipKey="RESET_REFERENCE_LAYER_POS"
                                 RenderOptions.BitmapInterpolationMode="HighQuality"
-                                Width="24" Height="24" HorizontalAlignment="Right"/>
+                                Width="24" Height="24" FontSize="18" HorizontalAlignment="Right"/>
                         <Button Cursor="Hand" DockPanel.Dock="Right"
                                 Command="{cmds:Command PixiEditor.Layer.TransformReferenceLayer}"
                                 Classes="pixi-icon"
                                 Content="{DynamicResource icon-crop}"
                                 ui:Translator.TooltipKey="TRANSFORM_REFERENCE_LAYER"
                                 RenderOptions.BitmapInterpolationMode="HighQuality"
-                                Width="24" Height="24" HorizontalAlignment="Right"/>
+                                Width="24" Height="24" FontSize="18" HorizontalAlignment="Right"/>
                         <TextBlock IsEnabled="{Binding ElementName=uc, Path=IsEnabled}" HorizontalAlignment="Center"
                                    Margin="0 0 5 0" Foreground="White"
-                                   FontSize="15" VerticalAlignment="Center" ui:Translator.Key="REFERENCE" />
+                                   FontSize="14" VerticalAlignment="Center" ui:Translator.Key="REFERENCE" />
                     </DockPanel>
                 </Grid>
             </controls:Shelf>

--- a/src/PixiEditor/Views/Layers/ReferenceLayer.axaml
+++ b/src/PixiEditor/Views/Layers/ReferenceLayer.axaml
@@ -22,6 +22,12 @@
         <Style Selector=":topmost Button#topmostBtn">
             <Setter Property="Content" Value="{DynamicResource icon-layers-bottom}"/>
         </Style>
+        <Style Selector="Grid#addRefArea">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="controls|Shelf#referenceShelf.noRef:pointerover">
+            <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+        </Style>
     </UserControl.Styles>
     <Border BorderThickness="0 2 0 0" MinWidth="60"
             Name="DragBorder"
@@ -30,29 +36,27 @@
             <behaviours:ClearFocusOnClickBehavior />
         </Interaction.Behaviors>
         <DockPanel Background="Transparent">
-            <controls:Shelf ControlToCollapse="{Binding RelativeSource={RelativeSource AncestorType=UserControl, Mode=FindAncestor}}">
+            <controls:Shelf x:Name="referenceShelf"
+                            Classes.noRef="{Binding Document.ReferenceLayerViewModel.ReferenceTexture, ElementName=uc, Converter={converters:NullToVisibilityConverter}}"
+                            ControlToCollapse="{Binding RelativeSource={RelativeSource AncestorType=UserControl, Mode=FindAncestor}}">
                 <Grid Height="40" x:Name="mainDockPanel">
-                    <Grid
-                        IsVisible="{Binding Document.ReferenceLayerViewModel.ReferenceTexture, ElementName=uc, Converter={converters:NullToVisibilityConverter}}"
-                        Panel.ZIndex="5">
-                        <Grid Cursor="Hand" IsVisible="{Binding ElementName=visibilityCheckbox, Path=!IsChecked}"
-                              Background="Transparent">
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" DockPanel.Dock="Left">
-                                <TextBlock Margin="5 0 5 0" VerticalAlignment="Center" FontSize="24" Text="{DynamicResource icon-add-reference}" Classes="pixi-icon"
-                                       IsVisible="{Binding Document.ReferenceLayerViewModel.ReferenceTexture, ElementName=uc, Converter={converters:NullToVisibilityConverter}}" />
-
-                                <TextBlock IsEnabled="{Binding ElementName=uc, Path=IsEnabled}"
-                                           Margin="0 0 5 0" Foreground="{DynamicResource ThemeForegroundBrush}"
-                                           FontSize="15" VerticalAlignment="Center"
-                                           ui:Translator.Key="ADD_REFERENCE_LAYER" />
-                            </StackPanel>
-                            <Interaction.Behaviors>
-                                <EventTriggerBehavior EventName="PointerReleased">
-                                    <InvokeCommandAction Command="{cmds:Command PixiEditor.Layer.ImportReferenceLayer}"
-                                                         PassEventArgsToCommand="True" />
-                                </EventTriggerBehavior>
-                            </Interaction.Behaviors>
-                        </Grid>
+                    <Grid x:Name="addRefArea"
+                          IsVisible="{Binding Document.ReferenceLayerViewModel.ReferenceTexture, ElementName=uc, Converter={converters:NullToVisibilityConverter}}"
+                          ZIndex="5"
+                          Cursor="Hand">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock Margin="5 0 5 0" VerticalAlignment="Center" FontSize="24" Text="{DynamicResource icon-add-reference}" Classes="pixi-icon" />
+                            <TextBlock IsEnabled="{Binding ElementName=uc, Path=IsEnabled}"
+                                       Margin="0 0 5 0" Foreground="{DynamicResource ThemeForegroundBrush}"
+                                       FontSize="15" VerticalAlignment="Center"
+                                       ui:Translator.Key="ADD_REFERENCE_LAYER" />
+                        </StackPanel>
+                        <Interaction.Behaviors>
+                            <EventTriggerBehavior EventName="PointerReleased">
+                                <InvokeCommandAction Command="{cmds:Command PixiEditor.Layer.ImportReferenceLayer}"
+                                                     PassEventArgsToCommand="True" />
+                            </EventTriggerBehavior>
+                        </Interaction.Behaviors>
                     </Grid>
 
                     <DockPanel Grid.Row="0" VerticalAlignment="Center" Height="40"

--- a/src/PixiEditor/Views/Main/ActionDisplayBar.axaml
+++ b/src/PixiEditor/Views/Main/ActionDisplayBar.axaml
@@ -21,7 +21,7 @@
             <ColumnDefinition
                 Width="*" />
             <ColumnDefinition
-                Width="290" />
+                Width="Auto" />
         </Grid.ColumnDefinitions>
         <!--<visuals:ColorsPreviewer/>-->
         <colorPicker:ColorDisplay
@@ -37,7 +37,6 @@
             <TextBlock
                 ui:Translator.LocalizedString="{Binding DataContext.ActiveActionDisplay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}"
                 Foreground="{DynamicResource ThemeForegroundBrush}"
-                FontSize="15"
                 Margin="10,0,0,0"
                 VerticalAlignment="Center" />
             <StackPanel
@@ -47,21 +46,18 @@
                 VerticalAlignment="Center">
                 <TextBlock
                     Text="{Binding DataContext.DocumentManagerSubViewModel.ActiveDocument.CoordinatesString, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}"
-                    Foreground="{DynamicResource ThemeForegroundBrush}"
-                    FontSize="16" />
+                    Foreground="{DynamicResource ThemeForegroundBrush}"  />
             </StackPanel>
         </DockPanel>
         <StackPanel
-            Margin="10,0,0,0"
+            Margin="10,0,10,0"
             VerticalAlignment="Center"
             Grid.Column="2"
             Orientation="Horizontal">
             <TextBlock
                 VerticalAlignment="Center"
-                Padding="10, 0"
                 HorizontalAlignment="Right"
                 Foreground="{DynamicResource ThemeForegroundBrush}"
-                FontSize="14"
                 ui:Translator.LocalizedString="{Binding DataContext.UpdateSubViewModel.VersionText, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" />
         </StackPanel>
     </Grid>

--- a/src/PixiEditor/Views/Main/MainTitleBar.axaml
+++ b/src/PixiEditor/Views/Main/MainTitleBar.axaml
@@ -33,8 +33,10 @@
                     <StackPanel Margin="5 0" Spacing="8" Orientation="Horizontal"
                                 Name="MainBarAdditionalElementPanel"
                                 DataContext="{Binding Path=DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType=main:MainTitleBar}}">
-                        <Border Width="24" Height="24" CornerRadius="4" Background="{DynamicResource FoundersPurpleLowBrush}">
+                        <Border Width="26" Height="26" CornerRadius="6" Background="{DynamicResource FoundersPurpleLowBrush}">
                             <Button Classes="pixi-icon"
+                                    Width="26"
+                                    Height="26"
                                     Foreground="{DynamicResource FoundersPurpleBrush}"
                                     FontSize="18"
                                     Content="{DynamicResource icon-extensions}"

--- a/src/PixiEditor/Views/Main/MainTitleBar.axaml
+++ b/src/PixiEditor/Views/Main/MainTitleBar.axaml
@@ -33,16 +33,15 @@
                     <StackPanel Margin="5 0" Spacing="8" Orientation="Horizontal"
                                 Name="MainBarAdditionalElementPanel"
                                 DataContext="{Binding Path=DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType=main:MainTitleBar}}">
-                        <Border Width="26" Height="26" CornerRadius="6" Background="{DynamicResource FoundersPurpleLowBrush}">
+                        <Border Width="24" Height="24" CornerRadius="6" Background="{DynamicResource FoundersPurpleLowBrush}">
                             <Button Classes="pixi-icon"
-                                    Width="26"
-                                    Height="26"
-                                    Foreground="{DynamicResource FoundersPurpleBrush}"
+                                    Width="24" Height="24"
                                     FontSize="18"
+                                    Foreground="{DynamicResource FoundersPurpleBrush}"
                                     Content="{DynamicResource icon-extensions}"
                                     Command="{xaml:Command Name=PixiEditor.Window.OpenExtensionsWindow}" />
                         </Border>
-                        <auth:UserAvatarToggle Width="26" Height="26" DataContext="{Binding Path=UserViewModel}" />
+                        <auth:UserAvatarToggle Width="24" Height="24" DataContext="{Binding Path=UserViewModel}" />
                     </StackPanel>
                 </dialogs:DialogTitleBar.AdditionalElement>
             </dialogs:DialogTitleBar>

--- a/src/PixiEditor/Views/Main/MiniAnimationPlayer.axaml
+++ b/src/PixiEditor/Views/Main/MiniAnimationPlayer.axaml
@@ -71,14 +71,14 @@
 
             </Grid>
         </Border>
-        <Button Classes="pixi-icon" FontSize="20" Content="{DynamicResource icon-timeline}"
+        <Button Classes="pixi-icon" Width="24" Height="24" FontSize="20" Content="{DynamicResource icon-timeline}"
                 Command="{xaml:Command UseProvided=True, Name=PixiEditor.Window.ShowDockWindow}"
-                CommandParameter="Timeline" 
+                CommandParameter="Timeline"
                 ui:Translator.TooltipKey="OPEN_TIMELINE"
                 />
-        <Button Classes="pixi-icon" FontSize="20" Content="{DynamicResource icon-nodes}"
+        <Button Classes="pixi-icon" Width="24" Height="24" FontSize="20" Content="{DynamicResource icon-nodes}"
                 Command="{xaml:Command UseProvided=True, Name=PixiEditor.Window.ShowDockWindow}"
-                CommandParameter="NodeGraph" 
+                CommandParameter="NodeGraph"
                 ui:Translator.TooltipKey="OPEN_NODE_GRAPH"
                 />
     </StackPanel>

--- a/src/PixiEditor/Views/Main/MiniAnimationPlayer.axaml
+++ b/src/PixiEditor/Views/Main/MiniAnimationPlayer.axaml
@@ -9,10 +9,12 @@
              x:Class="PixiEditor.Views.Main.MiniAnimationPlayer" Width="150">
     <StackPanel Orientation="Horizontal" Spacing="5">
         <Border Background="{DynamicResource ThemeBackgroundBrush}"
+                Height="25"
                 BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                 BorderThickness="1"
                 CornerRadius="{DynamicResource ControlCornerRadius}">
             <Grid
+                Height="25"
                 Width="75"
                 DataContext="{Binding RelativeSource={RelativeSource AncestorType=main:MiniAnimationPlayer, Mode=FindAncestor}}">
                 <Slider Minimum="1"
@@ -61,7 +63,7 @@
                         </ControlTemplate>
                     </Slider.Template>
                 </Slider>
-                <ToggleButton Width="24" Foreground="{DynamicResource SelectedHandleBrush}"
+                <ToggleButton Width="24" Height="24" Foreground="{DynamicResource SelectedHandleBrush}"
                               VerticalAlignment="Center"
                               HorizontalAlignment="Center"
                               ui:Translator.TooltipKey="TOGGLE_PLAY"

--- a/src/PixiEditor/Views/Main/Tools/ToolPickerButton.axaml
+++ b/src/PixiEditor/Views/Main/Tools/ToolPickerButton.axaml
@@ -23,9 +23,19 @@
             Width="44" Height="34"
             ui:Translator.TooltipLocalizedString="{Binding Tooltip}"
             Background="{DynamicResource ThemeBackgroundBrush1}">
+        <Button.Styles>
+            <Style Selector="Border#HoverBorder">
+                <Setter Property="Background" Value="Transparent" />
+            </Style>
+            <Style Selector="Button:pointerover Border#HoverBorder">
+                <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+            </Style>
+        </Button.Styles>
         <Button.Template>
             <ControlTemplate>
-                <Border Height="34" Width="34"
+                <Border Name="HoverBorder"
+                        Height="34" Width="34"
+                        CornerRadius="6"
                         Background="{DynamicResource ThemeBackgroundBrush1}">
                     <ContentPresenter Content="{TemplateBinding Content}" />
                 </Border>

--- a/src/PixiEditor/Views/Overlays/TogglableFlyout.axaml
+++ b/src/PixiEditor/Views/Overlays/TogglableFlyout.axaml
@@ -8,11 +8,23 @@
              d:DesignHeight="380" d:DesignWidth="200" Name="togglableFlyout">
     <Border Background="Transparent">
         <StackPanel Orientation="Vertical">
-            <Border HorizontalAlignment="{Binding ElementName=togglableFlyout, Path=HorizontalAlignment}" Background="{DynamicResource ThemeBackgroundBrush1}"
+            <Border HorizontalAlignment="{Binding ElementName=togglableFlyout, Path=HorizontalAlignment}"
                     CornerRadius="{DynamicResource ControlCornerRadius}"
                     BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                     BorderThickness="{DynamicResource ThemeBorderThickness}" Padding="5"
-                    x:Name="btnBorder">
+                    x:Name="btnBorder"
+                    Classes.checked="{Binding IsChecked, ElementName=toggleButton}">
+                <Border.Styles>
+                    <Style Selector="Border#btnBorder">
+                        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush1}" />
+                    </Style>
+                    <Style Selector="Border#btnBorder:pointerover">
+                        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+                    </Style>
+                    <Style Selector="Border#btnBorder.checked">
+                        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+                    </Style>
+                </Border.Styles>
                 <ToggleButton Padding="0" Margin="0"
                               IsChecked="{Binding IsOpen, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=UserControl}}"
                               x:Name="toggleButton" BorderThickness="0"

--- a/src/PixiEditor/Views/Palettes/PaletteColorAdder.axaml
+++ b/src/PixiEditor/Views/Palettes/PaletteColorAdder.axaml
@@ -16,12 +16,12 @@
             UseHintColor="True" HintColor="{Binding ElementName=paletteColorAdder, Path=HintColor}"
             Width="50" Focusable="False"
             ShowAlpha="False"/>
-        <Button Name="AddButton" Width="24" Height="24" 
+        <Button Name="AddButton" Width="24" Height="24" FontSize="18"
                 Classes="pixi-icon"
                 Content="{DynamicResource icon-plus-square}"
                 ui:Translator.TooltipKey="ADD_COLOR_TO_PALETTE"
                 Cursor="Hand" Click="Button_Click"/>
-        <Button Name="AddFromSwatches" Width="24" Height="24" 
+        <Button Name="AddFromSwatches" Width="24" Height="24" FontSize="18"
                 Classes="pixi-icon"
                 ui:Translator.TooltipKey="ADD_FROM_SWATCHES"
                 Cursor="Hand" Click="AddFromSwatches_OnClick"

--- a/src/PixiEditor/Views/Palettes/PaletteItem.axaml
+++ b/src/PixiEditor/Views/Palettes/PaletteItem.axaml
@@ -20,6 +20,14 @@
         <Style Selector="palettes|PaletteItem:favourite Button#FavouriteButton">
             <Setter Property="Content" Value="{DynamicResource icon-star-filled}" />
         </Style>
+        <Style Selector="palettes|PaletteItem Button#renameButton">
+            <Setter Property="Opacity" Value="0" />
+            <Setter Property="IsHitTestVisible" Value="False" />
+        </Style>
+        <Style Selector="palettes|PaletteItem:pointerover Button#renameButton">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="IsHitTestVisible" Value="True" />
+        </Style>
     </UserControl.Styles>
     <Grid Background="{DynamicResource ThemeBackgroundBrush}">
         <Grid.ColumnDefinitions>
@@ -33,13 +41,15 @@
         <StackPanel Orientation="Vertical" Grid.RowSpan="2" Grid.ColumnSpan="2">
             <Separator Background="{DynamicResource ThemeBackgroundBrush1}" />
             <DockPanel>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
                     <input:EditableTextBlock x:Name="titleTextBlock" OnSubmit="EditableTextBlock_OnSubmit"
                                              Text="{Binding Palette.Name, ElementName=paletteItem, Mode=TwoWay}"
+                                             VerticalAlignment="Center"
                                              FontSize="20" MaxChars="50" />
-                    <Button IsVisible="{Binding ElementName=paletteItem, Path=IsPointerOver}"
+                    <Button Name="renameButton"
                             Click="RenameButton_Click"
-                            Cursor="Hand" FontSize="20" Classes="pixi-icon"
+                            Cursor="Hand" Width="28" Height="28" Padding="2" FontSize="18"
+                            Classes="pixi-icon"
                             Content="{DynamicResource icon-edit}" Margin="5 0 0 0" />
                 </StackPanel>
                 <decorators:Chip Margin="0 5 5 0"
@@ -48,7 +58,7 @@
             </DockPanel>
             <TextBlock Margin="0 5 0 0" />
         </StackPanel>
-        <ItemsControl Margin="0 -20 0 10" Grid.Row="1" Grid.Column="0"
+        <ItemsControl Margin="0 -15 0 10" Grid.Row="1" Grid.Column="0"
                       ItemsSource="{Binding ElementName=paletteItem, Path=Palette.Colors}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
@@ -65,13 +75,13 @@
                     VerticalAlignment="Center">
             <Button
                 ui:Translator.TooltipKey="USE_IN_CURRENT_IMAGE" Cursor="Hand"
-                Margin="0 3 0 0" Padding="2" Width="28" Height="28"
+                Margin="0 3 0 0" Padding="2" Width="28" Height="28" FontSize="18"
                 CommandParameter="{Binding ElementName=paletteItem, Path=Palette.Colors}"
                 Classes="pixi-icon"
                 Content="{DynamicResource icon-check}"
                 Command="{Binding ImportPaletteCommand, ElementName=paletteItem}">
                 <Button.Styles>
-                    <Style Selector="Button:pointerover">
+                    <Style Selector="Button:pointerover /template/ ContentPresenter">
                         <Setter Property="Background" Value="SeaGreen" />
                     </Style>
                 </Button.Styles>
@@ -79,22 +89,22 @@
             <Button
                 Command="{Binding ElementName=paletteItem, Path=ToggleFavouriteCommand}"
                 CommandParameter="{Binding ElementName=paletteItem, Path=Palette}"
-                Name="FavouriteButton" Width="28" Height="28"
+                Name="FavouriteButton" Width="28" Height="28" FontSize="18"
                 Classes="pixi-icon" Padding="2"
                 ui:Translator.TooltipKey="ADD_TO_FAVORITES">
                 <Button.Styles>
-                    <Style Selector="Button:pointerover">
+                    <Style Selector="Button:pointerover /template/ ContentPresenter">
                         <Setter Property="Background" Value="Orange" />
                     </Style>
                 </Button.Styles>
             </Button>
             <Button Name="deleteButton" Command="{Binding DeletePaletteCommand, ElementName=paletteItem}"
                     CommandParameter="{Binding ElementName=paletteItem, Path=Palette}"
-                    Classes="pixi-icon" Width="28" Height="28"
+                    Classes="pixi-icon" Width="28" Height="28" FontSize="18"
                     Content="{DynamicResource icon-trash}"
                     ui:Translator.TooltipKey="DELETE" Padding="2" Margin="0" Cursor="Hand">
                 <Button.Styles>
-                    <Style Selector="Button:pointerover">
+                    <Style Selector="Button:pointerover /template/ ContentPresenter">
                         <Setter Property="Background" Value="Red" />
                     </Style>
                 </Button.Styles>

--- a/src/PixiEditor/Views/Palettes/PaletteViewer.axaml
+++ b/src/PixiEditor/Views/Palettes/PaletteViewer.axaml
@@ -44,16 +44,16 @@
                             <Button
                                 Classes="pixi-icon" Click="BrowsePalettes_Click"
                                 Content="{DynamicResource icon-database}"
-                                Cursor="Hand" Height="24" Width="24" ui:Translator.TooltipKey="BROWSE_PALETTES" />
+                                Cursor="Hand" Height="24" Width="24" FontSize="18" ui:Translator.TooltipKey="BROWSE_PALETTES" />
                             <Button Classes="pixi-icon"
-                                    Cursor="Hand" Height="24" Width="24" ui:Translator.TooltipKey="LOAD_PALETTE"
+                                    Cursor="Hand" Height="24" Width="24" FontSize="18" ui:Translator.TooltipKey="LOAD_PALETTE"
                                     Content="{DynamicResource icon-hard-drive}"
                                     Click="ImportPalette_OnClick" />
-                            <Button Height="24" Width="24" Classes="pixi-icon"
+                            <Button Height="24" Width="24" FontSize="18" Classes="pixi-icon"
                                     Content="{DynamicResource icon-save}"
                                     IsEnabled="{Binding ElementName=paletteControl, Path=Colors.Count}"
                                     Cursor="Hand" ui:Translator.TooltipKey="SAVE_PALETTE" Click="SavePalette_OnClick" />
-                            <Button Height="24" Width="24" Classes="pixi-icon"
+                            <Button Height="24" Width="24" FontSize="18" Classes="pixi-icon"
                                     Content="{DynamicResource icon-trash}"
                                     IsEnabled="{Binding ElementName=paletteControl, Path=Colors.Count}"
                                     Cursor="Hand" ui:Translator.TooltipKey="DISCARD_PALETTE"

--- a/src/PixiEditor/Views/Tools/ToolSettings/Settings/EnumSettingView.axaml
+++ b/src/PixiEditor/Views/Tools/ToolSettings/Settings/EnumSettingView.axaml
@@ -52,6 +52,10 @@
                         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
                         <Setter Property="Background" Value="Transparent" />
                     </Style>
+                    <Style Selector="ToggleButton:pointerover /template/ ContentPresenter">
+                        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+                        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+                    </Style>
                 </ItemsControl.Styles>
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>

--- a/src/PixiEditor/Views/Windows/PalettesBrowser.axaml
+++ b/src/PixiEditor/Views/Windows/PalettesBrowser.axaml
@@ -88,17 +88,17 @@
                         Margin="0 0 10 0">
                 <Button ui:Translator.TooltipKey="ADD_FROM_CURRENT_PALETTE"
                         Command="{Binding ElementName=palettesBrowser, Path=AddFromPaletteCommand}"
-                        Cursor="Hand" Margin="10 0" Classes="pixi-icon"
+                        Cursor="Hand" Margin="10 0 2.5 0" Classes="pixi-icon"
                         Content="{DynamicResource icon-plus-square}" />
-                <Button Cursor="Hand" Click="OpenFolder_OnClick" 
+                <Button Cursor="Hand" Click="OpenFolder_OnClick" Margin="2.5 0"
                         ui:Translator.TooltipKey="OPEN_PALETTES_DIR_TOOLTIP"
                         Classes="pixi-icon" Content="{DynamicResource icon-folder}" />
-                <Button HorizontalAlignment="Right" Margin="10 0 0 0"
+                <Button HorizontalAlignment="Right" Margin="2.5 0"
                         ui:Translator.TooltipKey="BROWSE_ON_LOSPEC_TOOLTIP"
                         Click="BrowseOnLospec_OnClick"
                         CommandParameter="https://lospec.com/palette-list" Classes="pixi-icon"
                         Content="{DynamicResource icon-globe}" />
-                <Button HorizontalAlignment="Right" Margin="10 0 0 0"
+                <Button HorizontalAlignment="Right" Margin="2.5 0 0 0"
                         ui:Translator.TooltipKey="IMPORT_FROM_FILE_TOOLTIP"
                         Click="ImportFromFile_OnClick" Classes="pixi-icon"
                         Content="{DynamicResource icon-hard-drive}" />

--- a/src/PixiEditor/Views/Windows/PalettesBrowser.axaml
+++ b/src/PixiEditor/Views/Windows/PalettesBrowser.axaml
@@ -48,6 +48,14 @@
                             <Setter Property="ui:Translator.TooltipKey" Value="ASCENDING" />
                             <Setter Property="Content" Value="{DynamicResource icon-chevrons-up}" />
                         </Style>
+                        <Style Selector="ToggleButton:pointerover /template/ ContentPresenter">
+                            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+                            <Setter Property="CornerRadius" Value="6" />
+                        </Style>
+                        <Style Selector="ToggleButton:checked:pointerover /template/ ContentPresenter">
+                            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+                            <Setter Property="CornerRadius" Value="6" />
+                        </Style>
                     </ToggleButton.Styles>
                 </ToggleButton>
                 <Label Margin="10 0 0 0" ui:Translator.Key="NAME" VerticalAlignment="Center" />
@@ -80,20 +88,18 @@
                         Margin="0 0 10 0">
                 <Button ui:Translator.TooltipKey="ADD_FROM_CURRENT_PALETTE"
                         Command="{Binding ElementName=palettesBrowser, Path=AddFromPaletteCommand}"
-                        Cursor="Hand" Margin="10 0" Width="24" Height="24" Classes="pixi-icon"
+                        Cursor="Hand" Margin="10 0" Classes="pixi-icon"
                         Content="{DynamicResource icon-plus-square}" />
-                <Button Cursor="Hand" Click="OpenFolder_OnClick" Width="24" Height="24"
+                <Button Cursor="Hand" Click="OpenFolder_OnClick" 
                         ui:Translator.TooltipKey="OPEN_PALETTES_DIR_TOOLTIP"
                         Classes="pixi-icon" Content="{DynamicResource icon-folder}" />
                 <Button HorizontalAlignment="Right" Margin="10 0 0 0"
                         ui:Translator.TooltipKey="BROWSE_ON_LOSPEC_TOOLTIP"
-                        Width="24" Height="24"
                         Click="BrowseOnLospec_OnClick"
                         CommandParameter="https://lospec.com/palette-list" Classes="pixi-icon"
                         Content="{DynamicResource icon-globe}" />
                 <Button HorizontalAlignment="Right" Margin="10 0 0 0"
                         ui:Translator.TooltipKey="IMPORT_FROM_FILE_TOOLTIP"
-                        Width="24" Height="24"
                         Click="ImportFromFile_OnClick" Classes="pixi-icon"
                         Content="{DynamicResource icon-hard-drive}" />
             </StackPanel>


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

- Made all text in the footer the same size and moved the coordinates and version to the bottom right corner
- Added hover fill when hovering over buttons

From original PR: https://github.com/PixiEditor/PixiEditor/pull/1522

 ## If possible, show examples of usage

New footer changes:
<img width="2556" height="84" alt="image" src="https://github.com/user-attachments/assets/f88dc04d-7b83-421d-a653-eea40d72e909" />

Previous 2.1.1.4 footer:
<img width="2558" height="93" alt="image" src="https://github.com/user-attachments/assets/44c9f998-03e7-45d6-81db-760366710c99" />

Hovering examples:

<img width="776" height="759" alt="PixiEditor Desktop_Newny3n1fb" src="https://github.com/user-attachments/assets/db1e6927-6867-4c00-9c30-cb7d51184840" />

<img width="534" height="194" alt="PixiEditor Desktop_4TNvE7BXGf" src="https://github.com/user-attachments/assets/1a5f0ba3-69b8-42bb-9224-ad5f141c648c" />

<img width="374" height="366" alt="PixiEditor Desktop_zyayHpl8Pp" src="https://github.com/user-attachments/assets/93728370-451e-4428-bdee-1369be575aa3" />

<img width="270" height="422" alt="PixiEditor Desktop_OaztwO7o2b" src="https://github.com/user-attachments/assets/bd0c3b5e-22ac-4edf-967e-4fd7c24bc8a8" />


## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
