### PR TITLE
Toolset selector placement change

### DIFF
--- a/src/PixiEditor.UI.Common/Accents/Base.axaml
+++ b/src/PixiEditor.UI.Common/Accents/Base.axaml
@@ -24,6 +24,7 @@
             <Color x:Key="ThemeControlMidColor">#303030</Color>
             <Color x:Key="ThemeControlHighColor">#404040</Color>
             <Color x:Key="ThemeControlHighlightColor">#515151</Color>
+            <Color x:Key="ThemeControlHigherHighlightColor">#626262</Color>
             <Color x:Key="HighlightForegroundColor">#FFFFFF</Color>
 
             <Color x:Key="ThemeBorderLowColor">#1A1A1A</Color>
@@ -153,6 +154,7 @@
             <SolidColorBrush x:Key="ThemeControlMidBrush" Color="{StaticResource ThemeControlMidColor}" />
             <SolidColorBrush x:Key="ThemeControlHighBrush" Color="{StaticResource ThemeControlHighColor}" />
             <SolidColorBrush x:Key="ThemeControlHighlightBrush" Color="{StaticResource ThemeControlHighlightColor}" />
+            <SolidColorBrush x:Key="ThemeControlHigherHighlightBrush" Color="{StaticResource ThemeControlHigherHighlightColor}" />
             <SolidColorBrush x:Key="ThemeHighlightForegroundBrush" Color="{StaticResource HighlightForegroundColor}" />
 
             <SolidColorBrush x:Key="ThemeBorderLowBrush" Color="{StaticResource ThemeBorderLowColor}" />

--- a/src/PixiEditor/Styles/DropdownPicker.Styles.axaml
+++ b/src/PixiEditor/Styles/DropdownPicker.Styles.axaml
@@ -1,0 +1,44 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style Selector="Button.dropdown-picker-button">
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    </Style>
+    <Style Selector="Button.dropdown-picker-button:pointerover">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+    </Style>
+    <Style Selector="Button.dropdown-picker-button.open">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+    </Style>
+    <Style Selector="Button.dropdown-picker-button:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    </Style>
+    <Style Selector="Button.dropdown-picker-button.open /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    </Style>
+
+    <Style Selector="Button.dropdown-picker-item">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="CornerRadius" Value="5" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="MinHeight" Value="27" />
+        <Setter Property="Padding" Value="8 5" />
+    </Style>
+    <Style Selector="Button.dropdown-picker-item:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHigherHighlightBrush}" />
+        <Setter Property="CornerRadius" Value="5" />
+    </Style>
+
+    <Style Selector="FlyoutPresenter.dropdown-picker-flyout">
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="4" />
+    </Style>
+</Styles>

--- a/src/PixiEditor/Styles/PixiEditor.Controls.axaml
+++ b/src/PixiEditor/Styles/PixiEditor.Controls.axaml
@@ -28,4 +28,5 @@
     <StyleInclude Source="avares://PixiEditor/Styles/Templates/NodePropertyViewTemplate.axaml"/>
     <StyleInclude Source="avares://PixiEditor/Styles/PortingWipStyles.axaml"/>
     <StyleInclude Source="avares://PixiEditor/Styles/ToolPickerButton.Styles.axaml"/>
+    <StyleInclude Source="avares://PixiEditor/Styles/DropdownPicker.Styles.axaml"/>
 </Styles>

--- a/src/PixiEditor/ViewModels/SubViewModels/ToolsViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/ToolsViewModel.cs
@@ -242,9 +242,10 @@ internal class ToolsViewModel : SubViewModel<ViewModelMain>, IToolsHandler
             }
         }
 
-        if (ActiveTool != null)
+        var suppressedToolbar = ActiveTool?.Toolbar;
+        if (suppressedToolbar != null)
         {
-            ActiveTool.Toolbar.SettingChanged -= ToolbarSettingChanged;
+            suppressedToolbar.SettingChanged -= ToolbarSettingChanged;
         }
 
         try
@@ -253,9 +254,9 @@ internal class ToolsViewModel : SubViewModel<ViewModelMain>, IToolsHandler
         }
         finally
         {
-            if (ActiveTool != null)
+            if (suppressedToolbar != null)
             {
-                ActiveTool.Toolbar.SettingChanged += ToolbarSettingChanged;
+                suppressedToolbar.SettingChanged += ToolbarSettingChanged;
             }
         }
 

--- a/src/PixiEditor/ViewModels/SubViewModels/ToolsViewModel.cs
+++ b/src/PixiEditor/ViewModels/SubViewModels/ToolsViewModel.cs
@@ -242,7 +242,23 @@ internal class ToolsViewModel : SubViewModel<ViewModelMain>, IToolsHandler
             }
         }
 
-        ActiveToolSet.ApplyToolSetSettings();
+        if (ActiveTool != null)
+        {
+            ActiveTool.Toolbar.SettingChanged -= ToolbarSettingChanged;
+        }
+
+        try
+        {
+            ActiveToolSet.ApplyToolSetSettings();
+        }
+        finally
+        {
+            if (ActiveTool != null)
+            {
+                ActiveTool.Toolbar.SettingChanged += ToolbarSettingChanged;
+            }
+        }
+
         UpdateEnabledState();
 
         SelectedToolChanged?.Invoke(this, new SelectedToolEventArgs(LastActionTool, ActiveTool));

--- a/src/PixiEditor/Views/Main/Tools/Toolbar.axaml
+++ b/src/PixiEditor/Views/Main/Tools/Toolbar.axaml
@@ -11,48 +11,22 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="PixiEditor.Views.Main.Tools.Toolbar">
     <UserControl.Resources>
-        <SolidColorBrush x:Key="DropdownItemHoverBrush" Color="#626262" />
+        <DataTemplate x:Key="ToolSetIconLabelTemplate" x:DataType="handlers:IToolSetHandler">
+            <StackPanel Orientation="Horizontal" Spacing="5">
+                <TextBlock VerticalAlignment="Center"
+                           Classes="pixi-icon"
+                           FontSize="14"
+                           Text="{Binding Icon}"
+                           IsVisible="{Binding IconIsPixiPerfect}" />
+                <Image Width="14" Height="14"
+                       Source="{Binding Icon, Converter={converters:ImagePathToBitmapConverter}}"
+                       IsVisible="{Binding !IconIsPixiPerfect}" />
+                <TextBlock VerticalAlignment="Center"
+                           FontSize="12"
+                           ui:Translator.Key="{Binding Name}" />
+            </StackPanel>
+        </DataTemplate>
     </UserControl.Resources>
-    <UserControl.Styles>
-        <Style Selector="Button.ToolSetDropdownItem">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="CornerRadius" Value="5" />
-            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-            <Setter Property="MinHeight" Value="27" />
-            <Setter Property="Padding" Value="8, 5" />
-        </Style>
-        <Style Selector="Button.ToolSetDropdownItem:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="{StaticResource DropdownItemHoverBrush}" />
-            <Setter Property="CornerRadius" Value="5" />
-        </Style>
-        <Style Selector="FlyoutPresenter.ToolSetDropdownFlyout">
-            <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-            <Setter Property="Padding" Value="4" />
-        </Style>
-        <Style Selector="Button.ToolSetDropdownButton">
-            <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
-            <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-        </Style>
-        <Style Selector="Button.ToolSetDropdownButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
-        </Style>
-        <Style Selector="Button.ToolSetDropdownButton.open">
-            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
-        </Style>
-        <Style Selector="Button.ToolSetDropdownButton:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-        </Style>
-        <Style Selector="Button.ToolSetDropdownButton.open /template/ ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-        </Style>
-    </UserControl.Styles>
     <Border CornerRadius="{DynamicResource ControlCornerRadius}"
             BorderBrush="{DynamicResource ThemeBorderMidBrush}"
             BorderThickness="{DynamicResource ThemeBorderThickness}"
@@ -79,50 +53,29 @@
                     Command="{cmds:Command PixiEditor.Undo.Redo}"
                     Width="36" Height="36"
                     Classes="pixi-icon"
-                    Margin="0, 0, 5, 0"
+                    Margin="0 0 5 0"
                     ui:Translator.TooltipKey="REDO">
                     <TextBlock Text="{DynamicResource icon-redo}" FontSize="20" />
                 </Button>
                 <Button Name="ToolSetDropdownButton"
-                        Classes="ToolSetDropdownButton"
+                        Classes="dropdown-picker-button"
                         VerticalAlignment="Center"
                         Height="25"
-                        Padding="6, 0"
-                        Margin="0, 0, 5, 0"
+                        Padding="6 0"
+                        Margin="0 0 5 0"
                         FontSize="12">
-                    <Button.Content>
-                        <Panel>
-                            <StackPanel Orientation="Horizontal" Spacing="5"
-                                        IsVisible="{Binding ToolsSubViewModel.ActiveToolSet.IconIsPixiPerfect}">
-                                <TextBlock VerticalAlignment="Center"
-                                           Classes="pixi-icon"
-                                           FontSize="14"
-                                           Text="{Binding ToolsSubViewModel.ActiveToolSet.Icon}" />
-                                <TextBlock VerticalAlignment="Center"
-                                           FontSize="12"
-                                           ui:Translator.Key="{Binding ToolsSubViewModel.ActiveToolSet.Name}" />
-                                <TextBlock VerticalAlignment="Center"
-                                           Classes="pixi-icon"
-                                           FontSize="14"
-                                           Text="{DynamicResource icon-chevron-down}" />
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Spacing="5"
-                                        IsVisible="{Binding !ToolsSubViewModel.ActiveToolSet.IconIsPixiPerfect}">
-                                <Image Width="14" Height="14"
-                                       Source="{Binding ToolsSubViewModel.ActiveToolSet.Icon, Converter={converters:ImagePathToBitmapConverter}}" />
-                                <TextBlock VerticalAlignment="Center"
-                                           FontSize="12"
-                                           ui:Translator.Key="{Binding ToolsSubViewModel.ActiveToolSet.Name}" />
-                                <TextBlock VerticalAlignment="Center"
-                                           Classes="pixi-icon"
-                                           FontSize="14"
-                                           Text="{DynamicResource icon-chevron-down}" />
-                            </StackPanel>
-                        </Panel>
-                    </Button.Content>
+                    <StackPanel Orientation="Horizontal" Spacing="5"
+                                DataContext="{Binding ToolsSubViewModel.ActiveToolSet}">
+                        <ContentControl Content="{Binding}"
+                                        ContentTemplate="{StaticResource ToolSetIconLabelTemplate}" />
+                        <TextBlock VerticalAlignment="Center"
+                                   Classes="pixi-icon"
+                                   FontSize="14"
+                                   Text="{DynamicResource icon-chevron-down}" />
+                    </StackPanel>
                     <Button.Flyout>
                         <Flyout Placement="Bottom"
-                                FlyoutPresenterClasses="ToolSetDropdownFlyout"
+                                FlyoutPresenterClasses="dropdown-picker-flyout"
                                 ShowMode="Standard"
                                 Opened="ToolSetDropdownFlyout_OnOpened"
                                 Closed="ToolSetDropdownFlyout_OnClosed">
@@ -135,77 +88,51 @@
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate x:DataType="{x:Type handlers:IToolSetHandler}">
-                                        <Button Classes="ToolSetDropdownItem"
+                                        <Button Classes="dropdown-picker-item"
                                                 HorizontalAlignment="Stretch"
                                                 HorizontalContentAlignment="Left"
                                                 FontSize="12"
                                                 Command="{cmds:Command PixiEditor.Tools.SetActiveToolSet, UseProvided=True}"
                                                 CommandParameter="{Binding}"
-                                                Click="ToolSetItem_OnClick">
-                                            <Panel>
-                                                <StackPanel Orientation="Horizontal" Spacing="5"
-                                                            IsVisible="{Binding IconIsPixiPerfect}">
-                                                    <TextBlock VerticalAlignment="Center"
-                                                               Classes="pixi-icon"
-                                                               FontSize="14"
-                                                               Text="{Binding Icon}" />
-                                                    <TextBlock VerticalAlignment="Center"
-                                                               FontSize="12"
-                                                               ui:Translator.Key="{Binding Name}" />
-                                                </StackPanel>
-                                                <StackPanel Orientation="Horizontal" Spacing="5"
-                                                            IsVisible="{Binding !IconIsPixiPerfect}">
-                                                    <Image Width="14" Height="14"
-                                                           Source="{Binding Icon, Converter={converters:ImagePathToBitmapConverter}}" />
-                                                    <TextBlock VerticalAlignment="Center"
-                                                               FontSize="12"
-                                                               ui:Translator.Key="{Binding Name}" />
-                                                </StackPanel>
-                                            </Panel>
-                                        </Button>
+                                                Click="ToolSetItem_OnClick"
+                                                Content="{Binding}"
+                                                ContentTemplate="{StaticResource ToolSetIconLabelTemplate}" />
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
                         </Flyout>
                     </Button.Flyout>
                 </Button>
-                <Grid Margin="5,5,10,5" Background="{DynamicResource ThemeBackgroundBrush2}" Width="5">
-                    <Grid.IsVisible>
+                <StackPanel Orientation="Horizontal">
+                    <StackPanel.IsVisible>
                         <MultiBinding Converter="{converters:AllTrueConverter}">
                             <Binding ElementName="CollapseButton" Path="!IsChecked" />
                             <Binding Path="ToolsSubViewModel.ActiveTool"
                                      Converter="{x:Static ObjectConverters.IsNotNull}" />
                         </MultiBinding>
-                    </Grid.IsVisible>
-                </Grid>
-                <Label CornerRadius="5" Background="{DynamicResource ThemeBackgroundBrush2}"
-                       Padding="8, 0" FontSize="12"
-                       Height="25"
-                       VerticalAlignment="Center"
-                       VerticalContentAlignment="Center"
-                       ui:Translator.Key="{Binding ToolsSubViewModel.ActiveTool.DisplayName.Key}"
-                       ui:Translator.TooltipLocalizedString="{Binding ToolsSubViewModel.ActiveTool.ActionDisplay}">
-                    <Label.IsVisible>
-                        <MultiBinding Converter="{converters:AllTrueConverter}">
-                            <Binding ElementName="CollapseButton" Path="!IsChecked" />
-                            <Binding Path="ToolsSubViewModel.ActiveTool"
-                                     Converter="{x:Static ObjectConverters.IsNotNull}" />
-                        </MultiBinding>
-                    </Label.IsVisible>
-                </Label>
+                    </StackPanel.IsVisible>
+                    <Grid Margin="5 5 10 5" Background="{DynamicResource ThemeBackgroundBrush2}" Width="5" />
+                    <Label CornerRadius="5" Background="{DynamicResource ThemeBackgroundBrush2}"
+                           Padding="8 0" FontSize="12"
+                           Height="25"
+                           VerticalAlignment="Center"
+                           VerticalContentAlignment="Center"
+                           ui:Translator.Key="{Binding ToolsSubViewModel.ActiveTool.DisplayName.Key}"
+                           ui:Translator.TooltipLocalizedString="{Binding ToolsSubViewModel.ActiveTool.ActionDisplay}" />
+                </StackPanel>
             </StackPanel>
             <ItemsControl VerticalAlignment="Center" Grid.Column="1"
                           IsVisible="{Binding ElementName=CollapseButton, Path=!IsChecked}"
                           ItemsSource="{Binding ToolsSubViewModel.ActiveTool.Toolbar.Settings}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <WrapPanel Orientation="Horizontal" Margin="0, 0, 0, 0" />
+                        <WrapPanel Orientation="Horizontal" Margin="0 0 0 0" />
                     </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="settings:Setting">
                         <StackPanel IsVisible="{Binding IsExposed}" Orientation="Horizontal"
-                                    VerticalAlignment="Center" Margin="5,0,5,0">
+                                    VerticalAlignment="Center" Margin="5 0 5 0">
                             <Label
                                 IsVisible="{Binding IsBuiltInLabelVisible}" VerticalAlignment="Center"
                                 FontSize="12"

--- a/src/PixiEditor/Views/Main/Tools/Toolbar.axaml
+++ b/src/PixiEditor/Views/Main/Tools/Toolbar.axaml
@@ -7,8 +7,52 @@
              xmlns:decorators="clr-namespace:PixiEditor.Views.Decorators"
              xmlns:settings="clr-namespace:PixiEditor.ViewModels.Tools.ToolSettings.Settings"
              xmlns:converters="clr-namespace:PixiEditor.Helpers.Converters"
+             xmlns:handlers="clr-namespace:PixiEditor.Models.Handlers"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="PixiEditor.Views.Main.Tools.Toolbar">
+    <UserControl.Resources>
+        <SolidColorBrush x:Key="DropdownItemHoverBrush" Color="#626262" />
+    </UserControl.Resources>
+    <UserControl.Styles>
+        <Style Selector="Button.ToolSetDropdownItem">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="CornerRadius" Value="5" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="MinHeight" Value="27" />
+            <Setter Property="Padding" Value="8, 5" />
+        </Style>
+        <Style Selector="Button.ToolSetDropdownItem:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource DropdownItemHoverBrush}" />
+            <Setter Property="CornerRadius" Value="5" />
+        </Style>
+        <Style Selector="FlyoutPresenter.ToolSetDropdownFlyout">
+            <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+            <Setter Property="Padding" Value="4" />
+        </Style>
+        <Style Selector="Button.ToolSetDropdownButton">
+            <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        </Style>
+        <Style Selector="Button.ToolSetDropdownButton:pointerover">
+            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+        </Style>
+        <Style Selector="Button.ToolSetDropdownButton.open">
+            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+        </Style>
+        <Style Selector="Button.ToolSetDropdownButton:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        </Style>
+        <Style Selector="Button.ToolSetDropdownButton.open /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        </Style>
+    </UserControl.Styles>
     <Border CornerRadius="{DynamicResource ControlCornerRadius}"
             BorderBrush="{DynamicResource ThemeBorderMidBrush}"
             BorderThickness="{DynamicResource ThemeBorderThickness}"
@@ -39,12 +83,116 @@
                     ui:Translator.TooltipKey="REDO">
                     <TextBlock Text="{DynamicResource icon-redo}" FontSize="20" />
                 </Button>
-                <Grid Margin="5,5,10,5" Background="{DynamicResource ThemeBackgroundBrush2}" Width="5"
-                      IsVisible="{Binding ElementName=CollapseButton, Path=!IsChecked}" />
-                <Label CornerRadius="5" Background="{DynamicResource ThemeBackgroundBrush2}" Padding="5" FontSize="12"
-                       VerticalAlignment="Center" IsVisible="{Binding ElementName=CollapseButton, Path=!IsChecked}"
+                <Button Name="ToolSetDropdownButton"
+                        Classes="ToolSetDropdownButton"
+                        VerticalAlignment="Center"
+                        Height="25"
+                        Padding="6, 0"
+                        Margin="0, 0, 5, 0"
+                        FontSize="12">
+                    <Button.Content>
+                        <Panel>
+                            <StackPanel Orientation="Horizontal" Spacing="5"
+                                        IsVisible="{Binding ToolsSubViewModel.ActiveToolSet.IconIsPixiPerfect}">
+                                <TextBlock VerticalAlignment="Center"
+                                           Classes="pixi-icon"
+                                           FontSize="14"
+                                           Text="{Binding ToolsSubViewModel.ActiveToolSet.Icon}" />
+                                <TextBlock VerticalAlignment="Center"
+                                           FontSize="12"
+                                           ui:Translator.Key="{Binding ToolsSubViewModel.ActiveToolSet.Name}" />
+                                <TextBlock VerticalAlignment="Center"
+                                           Classes="pixi-icon"
+                                           FontSize="14"
+                                           Text="{DynamicResource icon-chevron-down}" />
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="5"
+                                        IsVisible="{Binding !ToolsSubViewModel.ActiveToolSet.IconIsPixiPerfect}">
+                                <Image Width="14" Height="14"
+                                       Source="{Binding ToolsSubViewModel.ActiveToolSet.Icon, Converter={converters:ImagePathToBitmapConverter}}" />
+                                <TextBlock VerticalAlignment="Center"
+                                           FontSize="12"
+                                           ui:Translator.Key="{Binding ToolsSubViewModel.ActiveToolSet.Name}" />
+                                <TextBlock VerticalAlignment="Center"
+                                           Classes="pixi-icon"
+                                           FontSize="14"
+                                           Text="{DynamicResource icon-chevron-down}" />
+                            </StackPanel>
+                        </Panel>
+                    </Button.Content>
+                    <Button.Flyout>
+                        <Flyout Placement="Bottom"
+                                FlyoutPresenterClasses="ToolSetDropdownFlyout"
+                                ShowMode="Standard"
+                                Opened="ToolSetDropdownFlyout_OnOpened"
+                                Closed="ToolSetDropdownFlyout_OnClosed">
+                            <ItemsControl MinWidth="135"
+                                          ItemsSource="{Binding ToolsSubViewModel.NonSelectedToolSets}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Vertical" Spacing="2" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="{x:Type handlers:IToolSetHandler}">
+                                        <Button Classes="ToolSetDropdownItem"
+                                                HorizontalAlignment="Stretch"
+                                                HorizontalContentAlignment="Left"
+                                                FontSize="12"
+                                                Command="{cmds:Command PixiEditor.Tools.SetActiveToolSet, UseProvided=True}"
+                                                CommandParameter="{Binding}"
+                                                Click="ToolSetItem_OnClick">
+                                            <Panel>
+                                                <StackPanel Orientation="Horizontal" Spacing="5"
+                                                            IsVisible="{Binding IconIsPixiPerfect}">
+                                                    <TextBlock VerticalAlignment="Center"
+                                                               Classes="pixi-icon"
+                                                               FontSize="14"
+                                                               Text="{Binding Icon}" />
+                                                    <TextBlock VerticalAlignment="Center"
+                                                               FontSize="12"
+                                                               ui:Translator.Key="{Binding Name}" />
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal" Spacing="5"
+                                                            IsVisible="{Binding !IconIsPixiPerfect}">
+                                                    <Image Width="14" Height="14"
+                                                           Source="{Binding Icon, Converter={converters:ImagePathToBitmapConverter}}" />
+                                                    <TextBlock VerticalAlignment="Center"
+                                                               FontSize="12"
+                                                               ui:Translator.Key="{Binding Name}" />
+                                                </StackPanel>
+                                            </Panel>
+                                        </Button>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+                <Grid Margin="5,5,10,5" Background="{DynamicResource ThemeBackgroundBrush2}" Width="5">
+                    <Grid.IsVisible>
+                        <MultiBinding Converter="{converters:AllTrueConverter}">
+                            <Binding ElementName="CollapseButton" Path="!IsChecked" />
+                            <Binding Path="ToolsSubViewModel.ActiveTool"
+                                     Converter="{x:Static ObjectConverters.IsNotNull}" />
+                        </MultiBinding>
+                    </Grid.IsVisible>
+                </Grid>
+                <Label CornerRadius="5" Background="{DynamicResource ThemeBackgroundBrush2}"
+                       Padding="8, 0" FontSize="12"
+                       Height="25"
+                       VerticalAlignment="Center"
+                       VerticalContentAlignment="Center"
                        ui:Translator.Key="{Binding ToolsSubViewModel.ActiveTool.DisplayName.Key}"
-                       ui:Translator.TooltipLocalizedString="{Binding ToolsSubViewModel.ActiveTool.ActionDisplay}" />
+                       ui:Translator.TooltipLocalizedString="{Binding ToolsSubViewModel.ActiveTool.ActionDisplay}">
+                    <Label.IsVisible>
+                        <MultiBinding Converter="{converters:AllTrueConverter}">
+                            <Binding ElementName="CollapseButton" Path="!IsChecked" />
+                            <Binding Path="ToolsSubViewModel.ActiveTool"
+                                     Converter="{x:Static ObjectConverters.IsNotNull}" />
+                        </MultiBinding>
+                    </Label.IsVisible>
+                </Label>
             </StackPanel>
             <ItemsControl VerticalAlignment="Center" Grid.Column="1"
                           IsVisible="{Binding ElementName=CollapseButton, Path=!IsChecked}"
@@ -60,6 +208,8 @@
                                     VerticalAlignment="Center" Margin="5,0,5,0">
                             <Label
                                 IsVisible="{Binding IsBuiltInLabelVisible}" VerticalAlignment="Center"
+                                FontSize="12"
+                                Padding="5"
                                 Foreground="{DynamicResource ThemeForegroundBrush}"
                                 ui:Translator.TooltipKey="{Binding Tooltip}"
                                 ui:Translator.Key="{Binding Label.Key}" />
@@ -68,7 +218,7 @@
                                 Foreground="{DynamicResource ThemeForegroundBrush}"
                                 ui:Translator.TooltipKey="{Binding Tooltip}"
                                 Classes="pixi-icon"
-                                FontSize="18"
+                                FontSize="14"
                                 Padding="5 0"
                                 Text="{Binding Icon}">
                                 <TextBlock.IsVisible>
@@ -84,7 +234,8 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <StackPanel Grid.Column="2" Orientation="Horizontal">
+            <StackPanel Grid.Column="2" Orientation="Horizontal"
+                        IsVisible="{Binding ToolsSubViewModel.ActiveTool, Converter={x:Static ObjectConverters.IsNotNull}}">
                 <Border Margin="5 -5 5 -5" Width="1"
                         Background="{DynamicResource ThemeBackgroundBrush2}" />
                 <ToggleButton Name="CollapseButton" Classes="ExpandCollapseToggleStyle Right"

--- a/src/PixiEditor/Views/Main/Tools/Toolbar.axaml.cs
+++ b/src/PixiEditor/Views/Main/Tools/Toolbar.axaml.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
 
 namespace PixiEditor.Views.Main.Tools;
 
@@ -8,5 +10,36 @@ public partial class Toolbar : UserControl
     {
         InitializeComponent();
     }
-}
 
+    private void ToolSetItem_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Dispatcher.UIThread.Post(() => ToolSetDropdownButton.Flyout?.Hide());
+    }
+
+    private void ToolSetDropdownFlyout_OnOpened(object? sender, EventArgs e)
+    {
+        SetToolSetDropdownOpen(true);
+    }
+
+    private void ToolSetDropdownFlyout_OnClosed(object? sender, EventArgs e)
+    {
+        SetToolSetDropdownOpen(false);
+    }
+
+    private void SetToolSetDropdownOpen(bool isOpen)
+    {
+        const string openClass = "open";
+
+        if (isOpen)
+        {
+            if (!ToolSetDropdownButton.Classes.Contains(openClass))
+            {
+                ToolSetDropdownButton.Classes.Add(openClass);
+            }
+
+            return;
+        }
+
+        ToolSetDropdownButton.Classes.Remove(openClass);
+    }
+}

--- a/src/PixiEditor/Views/Main/Tools/Toolbar.axaml.cs
+++ b/src/PixiEditor/Views/Main/Tools/Toolbar.axaml.cs
@@ -12,34 +12,11 @@ public partial class Toolbar : UserControl
     }
 
     private void ToolSetItem_OnClick(object? sender, RoutedEventArgs e)
-    {
-        Dispatcher.UIThread.Post(() => ToolSetDropdownButton.Flyout?.Hide());
-    }
+        => Dispatcher.UIThread.Post(() => ToolSetDropdownButton.Flyout?.Hide());
 
     private void ToolSetDropdownFlyout_OnOpened(object? sender, EventArgs e)
-    {
-        SetToolSetDropdownOpen(true);
-    }
+        => ToolSetDropdownButton.Classes.Set("open", true);
 
     private void ToolSetDropdownFlyout_OnClosed(object? sender, EventArgs e)
-    {
-        SetToolSetDropdownOpen(false);
-    }
-
-    private void SetToolSetDropdownOpen(bool isOpen)
-    {
-        const string openClass = "open";
-
-        if (isOpen)
-        {
-            if (!ToolSetDropdownButton.Classes.Contains(openClass))
-            {
-                ToolSetDropdownButton.Classes.Add(openClass);
-            }
-
-            return;
-        }
-
-        ToolSetDropdownButton.Classes.Remove(openClass);
-    }
+        => ToolSetDropdownButton.Classes.Set("open", false);
 }

--- a/src/PixiEditor/Views/Main/ViewportControls/Viewport.axaml
+++ b/src/PixiEditor/Views/Main/ViewportControls/Viewport.axaml
@@ -169,82 +169,11 @@
             ZIndex="100" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="10, 10, 10, -95">
             <Grid.RowDefinitions>
                 <RowDefinition MinHeight="40" MaxHeight="120" />
-                <RowDefinition Height="30" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <tools:Toolbar
                 DataContext="{Binding Source={viewModels:MainVM}, Path=.}" />
-            <StackPanel Margin="0, 5, 0, 0" Grid.Row="1" Orientation="Horizontal" Name="toolsetsPanel">
-                <Border ClipToBounds="False"
-                        HorizontalAlignment="Left"
-                        Padding="5 0"
-                        Name="activeToolSetChip"
-                        Height="25"
-                        BorderBrush="{DynamicResource ThemeBorderHighBrush}"
-                        BorderThickness="1"
-                        Background="{DynamicResource ThemeBackgroundBrush2}"
-                        CornerRadius="{DynamicResource ControlCornerRadius}">
-                    <Panel>
-                        <TextBlock IsVisible="{Binding Source={viewModels:MainVM}, Path=ToolsSubViewModel.ActiveToolSet.IconIsPixiPerfect}">
-                            <Run Classes="pixi-icon"
-                                 Text="{Binding Source={viewModels:MainVM}, Path=ToolsSubViewModel.ActiveToolSet.Icon}" />
-                            <Run
-                                ui:Translator.Key="{Binding Source={viewModels:MainVM}, Path=ToolsSubViewModel.ActiveToolSet.Name}" />
-                        </TextBlock>
-                        <StackPanel Orientation="Horizontal" Spacing="5"
-                                    IsVisible="{Binding Source={viewModels:MainVM}, Path=!ToolsSubViewModel.ActiveToolSet.IconIsPixiPerfect}">
-                            <Image
-                                Width="16" Height="16"
-                                Source="{Binding Source={viewModels:MainVM}, Path=ToolsSubViewModel.ActiveToolSet.Icon, Converter={converters:ImagePathToBitmapConverter}}" />
-                            <TextBlock
-                                ui:Translator.Key="{Binding Source={viewModels:MainVM}, Path=ToolsSubViewModel.ActiveToolSet.Name}" />
-                        </StackPanel>
-                    </Panel>
-                </Border>
-                <ItemsControl
-                    Name="otherToolSets"
-                    Background="Transparent"
-                    ItemsSource="{Binding Source={viewModels:MainVM}, Path=ToolsSubViewModel.NonSelectedToolSets, Mode=OneWay}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <StackPanel Margin="5, 0, 0, 0" Spacing="5"
-                                        Orientation="Horizontal" />
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="{x:Type handlers:IToolSetHandler}">
-                            <Button
-                                Command="{xaml:Command PixiEditor.Tools.SetActiveToolSet, UseProvided=True}"
-                                CommandParameter="{Binding}"
-                                FontSize="{DynamicResource FontSizeMedium}"
-                                Padding="4, 2"
-                                VerticalAlignment="Center">
-                                <Panel>
-                                    <TextBlock IsVisible="{Binding IconIsPixiPerfect}">
-                                        <Run Classes="pixi-icon" Text="{Binding Icon}" />
-                                        <Run ui:Translator.Key="{Binding Name}" />
-                                    </TextBlock>
-                                    <StackPanel Orientation="Horizontal" Spacing="5" IsVisible="{Binding !IconIsPixiPerfect}">
-                                        <Image
-                                            Source="{Binding Icon, Converter={converters:ImagePathToBitmapConverter}}"/>
-                                        <TextBlock ui:Translator.Key="{Binding Name}" />
-                                    </StackPanel>
-                                </Panel>
-                            </Button>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                    <ItemsControl.IsVisible>
-                        <MultiBinding Converter="{converters:AnyTrueConverter}">
-                            <MultiBinding.Bindings>
-                                <Binding Path="IsPointerOver" ElementName="toolsPicker" />
-                                <Binding Path="IsPointerOver" ElementName="activeToolSetChip" />
-                                <Binding Path="IsPointerOver" ElementName="otherToolSets" />
-                            </MultiBinding.Bindings>
-                        </MultiBinding>
-                    </ItemsControl.IsVisible>
-                </ItemsControl>
-            </StackPanel>
-            <tools:ToolsPicker Grid.Row="2" IsHitTestVisible="True"
+            <tools:ToolsPicker Grid.Row="1" IsHitTestVisible="True"
                                Name="toolsPicker"
                                Padding="0, 5, 0, 0"
                                Background="Transparent"


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

- Moved toolset selector to toolbar

Relies on to function: https://github.com/PixiEditor/PixiEditor/pull/1533

From original PR: https://github.com/PixiEditor/PixiEditor/pull/1522

 ## If possible, show examples of usage

### Current PR:

<img width="877" height="365" alt="Actual Example" src="https://github.com/user-attachments/assets/65aad0fb-9af9-42cf-ad14-606a5f61fa43" />

### Alternate style concept:

<img width="1426" height="594" alt="Concept Example 1" src="https://github.com/user-attachments/assets/6895bd34-408e-4b4d-96a6-02ad15585b11" />

<img width="1426" height="594" alt="Concept Example 2" src="https://github.com/user-attachments/assets/b13590ef-316f-400f-9959-f8e6d06b7dff" />


## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
