### PR TITLE
Font picker change

### DIFF
--- a/src/PixiEditor.UI.Common/Accents/Base.axaml
+++ b/src/PixiEditor.UI.Common/Accents/Base.axaml
@@ -24,6 +24,7 @@
             <Color x:Key="ThemeControlMidColor">#303030</Color>
             <Color x:Key="ThemeControlHighColor">#404040</Color>
             <Color x:Key="ThemeControlHighlightColor">#515151</Color>
+            <Color x:Key="ThemeControlHigherHighlightColor">#626262</Color>
             <Color x:Key="HighlightForegroundColor">#FFFFFF</Color>
 
             <Color x:Key="ThemeBorderLowColor">#1A1A1A</Color>
@@ -153,6 +154,7 @@
             <SolidColorBrush x:Key="ThemeControlMidBrush" Color="{StaticResource ThemeControlMidColor}" />
             <SolidColorBrush x:Key="ThemeControlHighBrush" Color="{StaticResource ThemeControlHighColor}" />
             <SolidColorBrush x:Key="ThemeControlHighlightBrush" Color="{StaticResource ThemeControlHighlightColor}" />
+            <SolidColorBrush x:Key="ThemeControlHigherHighlightBrush" Color="{StaticResource ThemeControlHigherHighlightColor}" />
             <SolidColorBrush x:Key="ThemeHighlightForegroundBrush" Color="{StaticResource HighlightForegroundColor}" />
 
             <SolidColorBrush x:Key="ThemeBorderLowBrush" Color="{StaticResource ThemeBorderLowColor}" />

--- a/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorTextToolExecutor.cs
+++ b/src/PixiEditor/Models/DocumentModels/UpdateableChangeExecutors/VectorTextToolExecutor.cs
@@ -33,6 +33,10 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
     private Font? cachedFont;
     private bool isListeningForValidLayer;
     private VectorPath? onPath;
+    private Font? previewFont;
+    private bool isRestoringFromLayer;
+    private bool isStopped;
+    private bool isPreviewFontSubscribed;
 
     private VecD clickPos;
     private bool wasDrawingSize;
@@ -62,6 +66,7 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
         if (selectedMember is not IVectorLayerHandler layerHandler)
         {
             isListeningForValidLayer = true;
+            SubscribePreviewFontChanges();
             return ExecutionState.Success;
         }
 
@@ -80,20 +85,28 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
             document.TextOverlayHandler.Show(textData.Text, textData.Position, textData.Font,
                 textData.TransformationMatrix, textData.Spacing);
 
-            toolbar.Fill = textData.Fill;
-            toolbar.FillBrush = textData.FillPaintable.ToBrush();
-            toolbar.StrokeBrush = textData.Stroke.ToBrush();
-            toolbar.ToolSize = textData.StrokeWidth;
+            isRestoringFromLayer = true;
             try
             {
-                toolbar.FontFamily = textData.Font.Family;
-                toolbar.FontSize = textData.Font.Size;
-                toolbar.Spacing = textData.Spacing ?? textData.Font.Size;
-                toolbar.Bold = textData.Font.Bold;
-                toolbar.Italic = textData.Font.Italic;
+                toolbar.Fill = textData.Fill;
+                toolbar.FillBrush = textData.FillPaintable.ToBrush();
+                toolbar.StrokeBrush = textData.Stroke.ToBrush();
+                toolbar.ToolSize = textData.StrokeWidth;
+                try
+                {
+                    toolbar.FontFamily = textData.Font.Family;
+                    toolbar.FontSize = textData.Font.Size;
+                    toolbar.Spacing = textData.Spacing ?? textData.Font.Size;
+                    toolbar.Bold = textData.Font.Bold;
+                    toolbar.Italic = textData.Font.Italic;
+                }
+                catch (InvalidOperationException) // Native font likely disposed
+                {
+                }
             }
-            catch (InvalidOperationException) // Native font likely disposed
+            finally
             {
+                isRestoringFromLayer = false;
             }
 
             onPath = textData.Path;
@@ -119,6 +132,7 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
             return ExecutionState.Error;
         }
 
+        SubscribePreviewFontChanges();
         return ExecutionState.Success;
     }
 
@@ -189,6 +203,14 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
 
     public override void ForceStop()
     {
+        RestoreSelectedFontAfterPreview();
+
+        isStopped = true;
+
+        UnsubscribePreviewFontChanges();
+
+        RetirePreviewFont();
+
         internals.ActionAccumulator.AddFinishedActions(new EndSetShapeGeometry_Action());
         document?.TextOverlayHandler?.Hide();
 
@@ -221,6 +243,8 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
 
     public void OnTextChanged(string text)
     {
+        if (isStopped) return;
+
         var constructedText = ConstructTextData(text);
         internals.ActionAccumulator.AddFinishedActions(
             new SetShapeGeometry_Action(selectedMember.Id, constructedText, VectorShapeChangeType.GeometryData),
@@ -232,22 +256,29 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
 
     public override void OnSettingsChanged(string name, object value)
     {
+        if (isStopped) return;
         if (!document.TextOverlayHandler.IsActive) return;
 
-        if (isListeningForValidLayer)
+        if (isListeningForValidLayer || isRestoringFromLayer)
         {
             return;
         }
 
         if (name == nameof(ITextToolbar.FontFamily))
         {
-            fontsToDispose.Add(cachedFont);
+            RetirePreviewFont();
+            if (cachedFont != null)
+            {
+                fontsToDispose.Add(cachedFont);
+            }
+
             cachedFont = toolbar.ConstructFont();
             document.TextOverlayHandler.Font = cachedFont;
         }
         else
         {
-            if (cachedFont == null)
+            RetirePreviewFont();
+            if (cachedFont == null || cachedFont.IsDisposed)
             {
                 cachedFont = toolbar.ConstructFont();
             }
@@ -285,15 +316,15 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
         FontEdging previousEdging = constructedText.Font.Edging;
         bool previousAntiAlias = constructedText.AntiAlias;
         bool previousSubpixel = constructedText.Font.SubPixel;
+        bool equals = false;
 
-        if (previousData != null)
+        if (previousData?.Font is { IsDisposed: false })
         {
             constructedText.AntiAlias = previousData.AntiAlias;
             constructedText.Font.Edging = previousData.Font.Edging;
             constructedText.Font.SubPixel = previousData.Font.SubPixel;
+            equals = constructedText.Equals(previousData);
         }
-
-        bool equals = constructedText.Equals(previousData);
 
         constructedText.AntiAlias = previousAntiAlias;
         constructedText.Font.Edging = previousEdging;
@@ -353,9 +384,9 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
 
     private TextVectorData ConstructTextData(string text)
     {
-        if (cachedFont == null || cachedFont.Family.Name != toolbar.FontFamily.Name)
+        if (cachedFont == null || cachedFont.IsDisposed || cachedFont.Family.Name != toolbar.FontFamily.Name)
         {
-            Font toDispose = cachedFont;
+            Font? toDispose = cachedFont;
             Dispatcher.UIThread.Post(() =>
             {
                 toDispose?.Dispose();
@@ -384,6 +415,107 @@ internal class VectorTextToolExecutor : UpdateableChangeExecutor, ITextOverlayEv
             Path = onPath,
             // TODO: MaxWidth = toolbar.MaxWidth
         };
+    }
+
+    private void OnPreviewFontFamilyChanged(FontFamilyName? fontFamily)
+    {
+        if (isStopped) return;
+        if (!document.TextOverlayHandler.IsActive || isListeningForValidLayer)
+        {
+            return;
+        }
+
+        if (!fontFamily.HasValue)
+        {
+            RestoreSelectedFontAfterPreview();
+            return;
+        }
+
+        if (previewFont is { IsDisposed: false } && previewFont.Family.Name == fontFamily.Value.Name)
+        {
+            return;
+        }
+
+        RetirePreviewFont();
+
+        previewFont = Font.FromFontFamily(fontFamily.Value) ?? Font.CreateDefault();
+        previewFont.Size = toolbar.FontSize;
+        previewFont.Edging = toolbar.AntiAliasing ? FontEdging.AntiAlias : FontEdging.Alias;
+        previewFont.Bold = toolbar.Bold;
+        previewFont.Italic = toolbar.Italic;
+
+        ApplyPreviewFont(previewFont);
+    }
+
+    private void ApplyPreviewFont(Font fontToUse)
+    {
+        document.TextOverlayHandler.Font = null;
+        document.TextOverlayHandler.Font = fontToUse;
+
+        var constructedText = ConstructTextData(lastText);
+        constructedText.Font = fontToUse;
+
+        internals.ActionAccumulator.AddActions(
+            new SetShapeGeometry_Action(selectedMember.Id, constructedText, VectorShapeChangeType.OtherVisuals),
+            new SetLowDpiRendering_Action(selectedMember.Id, toolbar.ForceLowDpiRendering));
+    }
+
+    private void RestoreSelectedFontAfterPreview()
+    {
+        if (previewFont == null)
+        {
+            return;
+        }
+
+        RetirePreviewFont();
+
+        if (cachedFont == null || cachedFont.IsDisposed || cachedFont.Family.Name != toolbar.FontFamily.Name)
+        {
+            if (cachedFont is { IsDisposed: false })
+            {
+                fontsToDispose.Add(cachedFont);
+            }
+
+            cachedFont = toolbar.ConstructFont();
+        }
+
+        cachedFont.Size = toolbar.FontSize;
+        cachedFont.Bold = toolbar.Bold;
+        cachedFont.Italic = toolbar.Italic;
+
+        ApplyPreviewFont(cachedFont);
+    }
+
+    private void RetirePreviewFont()
+    {
+        if (previewFont is { IsDisposed: false })
+        {
+            fontsToDispose.Add(previewFont);
+        }
+
+        previewFont = null;
+    }
+
+    private void SubscribePreviewFontChanges()
+    {
+        if (isPreviewFontSubscribed)
+        {
+            return;
+        }
+
+        toolbar.PreviewFontFamilyChanged += OnPreviewFontFamilyChanged;
+        isPreviewFontSubscribed = true;
+    }
+
+    private void UnsubscribePreviewFontChanges()
+    {
+        if (!isPreviewFontSubscribed || toolbar == null)
+        {
+            return;
+        }
+
+        toolbar.PreviewFontFamilyChanged -= OnPreviewFontFamilyChanged;
+        isPreviewFontSubscribed = false;
     }
 
     bool IExecutorFeature.IsFeatureEnabled<T>()

--- a/src/PixiEditor/Models/Handlers/Toolbars/ITextToolbar.cs
+++ b/src/PixiEditor/Models/Handlers/Toolbars/ITextToolbar.cs
@@ -4,6 +4,8 @@ namespace PixiEditor.Models.Handlers.Toolbars;
 
 internal interface ITextToolbar : IFillableShapeToolbar
 {
+    public event Action<FontFamilyName?> PreviewFontFamilyChanged;
+
     public double FontSize { get; set; }
     public FontFamilyName FontFamily { get; set; }
     public double Spacing { get; set; }

--- a/src/PixiEditor/Styles/DropdownPicker.Styles.axaml
+++ b/src/PixiEditor/Styles/DropdownPicker.Styles.axaml
@@ -1,15 +1,18 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Style Selector="Button.dropdown-picker-button">
+    <!-- ===== Trigger button (Button + DropDownButton) ===== -->
+    <Style Selector=":is(Button).dropdown-picker-button">
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     </Style>
-    <Style Selector="Button.dropdown-picker-button:pointerover">
+    <Style Selector=":is(Button).dropdown-picker-button:pointerover">
         <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
     </Style>
+
+    <!-- Button: keep highlighted while flyout is open (driven by .open class from code-behind) -->
     <Style Selector="Button.dropdown-picker-button.open">
         <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
     </Style>
@@ -22,6 +25,15 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     </Style>
 
+    <!-- DropDownButton: override its RootBorder background for the same hover/pressed feel -->
+    <Style Selector="DropDownButton.dropdown-picker-button:pointerover /template/ Border#RootBorder">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+    </Style>
+    <Style Selector="DropDownButton.dropdown-picker-button:pressed /template/ Border#RootBorder">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+    </Style>
+
+    <!-- ===== Click-style items (Button) — used by ItemsControl pickers ===== -->
     <Style Selector="Button.dropdown-picker-item">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
@@ -35,6 +47,26 @@
         <Setter Property="CornerRadius" Value="5" />
     </Style>
 
+    <!-- ===== Selection-style items (ListBox / ListBoxItem) — used by ListBox pickers ===== -->
+    <Style Selector="ListBox.dropdown-picker-list">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="0" />
+    </Style>
+    <Style Selector="ListBox.dropdown-picker-list ListBoxItem">
+        <Setter Property="CornerRadius" Value="5" />
+        <Setter Property="Height" Value="28" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Padding" Value="8 0" />
+    </Style>
+    <Style Selector="ListBox.dropdown-picker-list ListBoxItem:pointerover /template/ Border">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHigherHighlightBrush}" />
+    </Style>
+    <Style Selector="ListBox.dropdown-picker-list ListBoxItem:selected /template/ Border">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+    </Style>
+
+    <!-- ===== Flyout presenter ===== -->
     <Style Selector="FlyoutPresenter.dropdown-picker-flyout">
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />

--- a/src/PixiEditor/Styles/DropdownPicker.Styles.axaml
+++ b/src/PixiEditor/Styles/DropdownPicker.Styles.axaml
@@ -1,0 +1,44 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style Selector="Button.dropdown-picker-button">
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    </Style>
+    <Style Selector="Button.dropdown-picker-button:pointerover">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+    </Style>
+    <Style Selector="Button.dropdown-picker-button.open">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+    </Style>
+    <Style Selector="Button.dropdown-picker-button:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    </Style>
+    <Style Selector="Button.dropdown-picker-button.open /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    </Style>
+
+    <Style Selector="Button.dropdown-picker-item">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="CornerRadius" Value="5" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="MinHeight" Value="27" />
+        <Setter Property="Padding" Value="8 5" />
+    </Style>
+    <Style Selector="Button.dropdown-picker-item:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ThemeControlHigherHighlightBrush}" />
+        <Setter Property="CornerRadius" Value="5" />
+    </Style>
+
+    <Style Selector="FlyoutPresenter.dropdown-picker-flyout">
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="4" />
+    </Style>
+</Styles>

--- a/src/PixiEditor/Styles/PixiEditor.Controls.axaml
+++ b/src/PixiEditor/Styles/PixiEditor.Controls.axaml
@@ -28,4 +28,5 @@
     <StyleInclude Source="avares://PixiEditor/Styles/Templates/NodePropertyViewTemplate.axaml"/>
     <StyleInclude Source="avares://PixiEditor/Styles/PortingWipStyles.axaml"/>
     <StyleInclude Source="avares://PixiEditor/Styles/ToolPickerButton.Styles.axaml"/>
+    <StyleInclude Source="avares://PixiEditor/Styles/DropdownPicker.Styles.axaml"/>
 </Styles>

--- a/src/PixiEditor/ViewModels/Tools/ToolSettings/Settings/FontFamilySettingViewModel.cs
+++ b/src/PixiEditor/ViewModels/Tools/ToolSettings/Settings/FontFamilySettingViewModel.cs
@@ -17,6 +17,9 @@ internal class FontFamilySettingViewModel : Setting<FontFamilyName>
 {
     private ObservableCollection<FontFamilyName> allFonts;
     private int selectedIndex;
+    private int previewFontIndex = -1;
+
+    public event Action<FontFamilyName?> PreviewFontFamilyChanged;
 
     public int FontIndex
     {
@@ -28,14 +31,34 @@ internal class FontFamilySettingViewModel : Setting<FontFamilyName>
         {
             SetProperty(ref selectedIndex, value);
 
-            if (Fonts?.Count > 0)
+            if (Fonts?.Count > 0 && value >= 0 && value < Fonts.Count)
             {
                 Value = Fonts[value];
             }
-            else
+            else if (Fonts?.Count is null or 0)
             {
                 Value = FontLibrary.DefaultFontFamily;
             }
+        }
+    }
+
+    public int PreviewFontIndex
+    {
+        get => previewFontIndex;
+        set
+        {
+            if (!SetProperty(ref previewFontIndex, value))
+            {
+                return;
+            }
+
+            if (Fonts?.Count > 0 && value >= 0 && value < Fonts.Count)
+            {
+                PreviewFontFamilyChanged?.Invoke(Fonts[value]);
+                return;
+            }
+
+            PreviewFontFamilyChanged?.Invoke(null);
         }
     }
 

--- a/src/PixiEditor/ViewModels/Tools/ToolSettings/Toolbars/TextToolbar.cs
+++ b/src/PixiEditor/ViewModels/Tools/ToolSettings/Toolbars/TextToolbar.cs
@@ -9,6 +9,8 @@ namespace PixiEditor.ViewModels.Tools.ToolSettings.Toolbars;
 
 internal class TextToolbar : FillableShapeToolbar, ITextToolbar
 {
+    public event Action<FontFamilyName?> PreviewFontFamilyChanged;
+
     public FontFamilyName FontFamily
     {
         get
@@ -106,7 +108,9 @@ internal class TextToolbar : FillableShapeToolbar, ITextToolbar
 
     public TextToolbar()
     {
-        AddSetting(new FontFamilySettingViewModel(nameof(FontFamily), ""));
+        var fontFamilySetting = new FontFamilySettingViewModel(nameof(FontFamily), "");
+        fontFamilySetting.PreviewFontFamilyChanged += fontFamily => PreviewFontFamilyChanged?.Invoke(fontFamily);
+        AddSetting(fontFamilySetting);
         FontFamily = FontLibrary.DefaultFontFamily;
         
         var sizeSetting =

--- a/src/PixiEditor/Views/Input/FontFamilyPicker.axaml
+++ b/src/PixiEditor/Views/Input/FontFamilyPicker.axaml
@@ -6,54 +6,16 @@
              xmlns:converters="clr-namespace:PixiEditor.Helpers.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="PixiEditor.Views.Input.FontFamilyPicker">
-    <UserControl.Resources>
-        <SolidColorBrush x:Key="DropdownItemHoverBrush" Color="#626262" />
-    </UserControl.Resources>
-    <UserControl.Styles>
-        <Style Selector="FlyoutPresenter.FontFamilyPickerFlyout">
-            <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-            <Setter Property="Padding" Value="4" />
-        </Style>
-        <Style Selector="DropDownButton.FontFamilyPickerButton:pointerover /template/ Border#RootBorder">
-            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
-        </Style>
-        <Style Selector="DropDownButton.FontFamilyPickerButton:pressed /template/ Border#RootBorder">
-            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
-        </Style>
-        <Style Selector="ListBox.FontFamilyPickerList">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Padding" Value="0" />
-        </Style>
-        <Style Selector="ListBox.FontFamilyPickerList ListBoxItem">
-            <Setter Property="CornerRadius" Value="5" />
-            <Setter Property="Height" Value="28" />
-            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-            <Setter Property="Padding" Value="8, 0" />
-        </Style>
-        <Style Selector="ListBox.FontFamilyPickerList ListBoxItem:pointerover /template/ Border">
-            <Setter Property="Background" Value="{StaticResource DropdownItemHoverBrush}" />
-        </Style>
-        <Style Selector="ListBox.FontFamilyPickerList ListBoxItem:selected /template/ Border">
-            <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
-        </Style>
-    </UserControl.Styles>
     <StackPanel Orientation="Horizontal" Spacing="5" DataContext="{Binding RelativeSource={RelativeSource AncestorType=UserControl}}">
         <Button Classes="pixi-icon" FontSize="16"
                 ui:Translator.TooltipKey="CUSTOM_FONT"
                 Command="{Binding UploadFontCommand}" Content="{DynamicResource icon-upload}" />
         <DropDownButton x:Name="FontDropDown"
-                        Classes="FontFamilyPickerButton"
+                        Classes="dropdown-picker-button"
                         Width="150"
                         Height="25"
-                        Padding="8,0"
-                        Focusable="False"
-                        Background="{DynamicResource ThemeBackgroundBrush2}"
-                        BorderBrush="{DynamicResource ThemeBorderHighBrush}"
-                        BorderThickness="1"
-                        CornerRadius="{DynamicResource ControlCornerRadius}">
+                        Padding="8 0"
+                        Focusable="False">
             <DropDownButton.Content>
                 <TextBlock Text="{Binding SelectedFontFamily.Name}"
                            TextTrimming="CharacterEllipsis"
@@ -61,11 +23,11 @@
             </DropDownButton.Content>
             <DropDownButton.Flyout>
                 <Flyout Placement="BottomEdgeAlignedLeft"
-                        FlyoutPresenterClasses="FontFamilyPickerFlyout"
+                        FlyoutPresenterClasses="dropdown-picker-flyout"
                         ShowMode="Standard"
                         Closed="FontFlyout_OnClosed">
                     <ListBox x:Name="FontList"
-                             Classes="FontFamilyPickerList"
+                             Classes="dropdown-picker-list"
                              Width="190"
                              MaxHeight="280"
                              ItemsSource="{Binding Fonts}"

--- a/src/PixiEditor/Views/Input/FontFamilyPicker.axaml
+++ b/src/PixiEditor/Views/Input/FontFamilyPicker.axaml
@@ -6,20 +6,90 @@
              xmlns:converters="clr-namespace:PixiEditor.Helpers.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="PixiEditor.Views.Input.FontFamilyPicker">
+    <UserControl.Resources>
+        <SolidColorBrush x:Key="DropdownItemHoverBrush" Color="#626262" />
+    </UserControl.Resources>
+    <UserControl.Styles>
+        <Style Selector="FlyoutPresenter.FontFamilyPickerFlyout">
+            <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush2}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+            <Setter Property="Padding" Value="4" />
+        </Style>
+        <Style Selector="DropDownButton.FontFamilyPickerButton:pointerover /template/ Border#RootBorder">
+            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+        </Style>
+        <Style Selector="DropDownButton.FontFamilyPickerButton:pressed /template/ Border#RootBorder">
+            <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightBrush}" />
+        </Style>
+        <Style Selector="ListBox.FontFamilyPickerList">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
+        </Style>
+        <Style Selector="ListBox.FontFamilyPickerList ListBoxItem">
+            <Setter Property="CornerRadius" Value="5" />
+            <Setter Property="Height" Value="28" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Padding" Value="8, 0" />
+        </Style>
+        <Style Selector="ListBox.FontFamilyPickerList ListBoxItem:pointerover /template/ Border">
+            <Setter Property="Background" Value="{StaticResource DropdownItemHoverBrush}" />
+        </Style>
+        <Style Selector="ListBox.FontFamilyPickerList ListBoxItem:selected /template/ Border">
+            <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}" />
+        </Style>
+    </UserControl.Styles>
     <StackPanel Orientation="Horizontal" Spacing="5" DataContext="{Binding RelativeSource={RelativeSource AncestorType=UserControl}}">
         <Button Classes="pixi-icon" FontSize="16"
                 ui:Translator.TooltipKey="CUSTOM_FONT"
                 Command="{Binding UploadFontCommand}" Content="{DynamicResource icon-upload}" />
-        <ComboBox VerticalAlignment="Center"
-                  MinWidth="85"
-                  ItemsSource="{Binding Fonts}"
-                  SelectedIndex="{Binding FontIndex, Mode=TwoWay}">
-            <ComboBox.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock Text="{Binding Name}"
-                               FontFamily="{Binding Converter={converters:FontFamilyNameToAvaloniaFontFamily}}" />
-                </DataTemplate>
-            </ComboBox.ItemTemplate>
-        </ComboBox>
+        <DropDownButton x:Name="FontDropDown"
+                        Classes="FontFamilyPickerButton"
+                        Width="150"
+                        Height="25"
+                        Padding="8,0"
+                        Focusable="False"
+                        Background="{DynamicResource ThemeBackgroundBrush2}"
+                        BorderBrush="{DynamicResource ThemeBorderHighBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{DynamicResource ControlCornerRadius}">
+            <DropDownButton.Content>
+                <TextBlock Text="{Binding SelectedFontFamily.Name}"
+                           TextTrimming="CharacterEllipsis"
+                           FontFamily="{Binding SelectedFontFamily, Converter={converters:FontFamilyNameToAvaloniaFontFamily}}" />
+            </DropDownButton.Content>
+            <DropDownButton.Flyout>
+                <Flyout Placement="BottomEdgeAlignedLeft"
+                        FlyoutPresenterClasses="FontFamilyPickerFlyout"
+                        ShowMode="Standard"
+                        Closed="FontFlyout_OnClosed">
+                    <ListBox x:Name="FontList"
+                             Classes="FontFamilyPickerList"
+                             Width="190"
+                             MaxHeight="280"
+                             ItemsSource="{Binding Fonts}"
+                             SelectedIndex="{Binding FontIndex, Mode=TwoWay}"
+                             SelectionChanged="FontList_OnSelectionChanged"
+                             PointerExited="FontList_OnPointerExited"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="Transparent"
+                                        PointerEntered="FontItem_OnPointerEntered"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Stretch">
+                                    <TextBlock Text="{Binding Name}"
+                                               FontFamily="{Binding Converter={converters:FontFamilyNameToAvaloniaFontFamily}}"
+                                               VerticalAlignment="Center"
+                                               TextTrimming="CharacterEllipsis" />
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </Flyout>
+            </DropDownButton.Flyout>
+        </DropDownButton>
     </StackPanel>
 </UserControl>

--- a/src/PixiEditor/Views/Input/FontFamilyPicker.axaml.cs
+++ b/src/PixiEditor/Views/Input/FontFamilyPicker.axaml.cs
@@ -3,6 +3,7 @@ using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input;
 using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.Input;
 using Drawie.Backend.Core.Text;
@@ -38,12 +39,21 @@ public partial class FontFamilyPicker : UserControl
     }
 
     public static readonly StyledProperty<int> FontIndexProperty = AvaloniaProperty.Register<FontFamilyPicker, int>(
-        nameof(FontIndex));
+        nameof(FontIndex), defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
+
+    public static readonly StyledProperty<int> PreviewFontIndexProperty = AvaloniaProperty.Register<FontFamilyPicker, int>(
+        nameof(PreviewFontIndex), -1, defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
 
     public int FontIndex
     {
         get => GetValue(FontIndexProperty);
         set => SetValue(FontIndexProperty, value);
+    }
+
+    public int PreviewFontIndex
+    {
+        get => GetValue(PreviewFontIndexProperty);
+        set => SetValue(PreviewFontIndexProperty, value);
     }
 
     public ICommand UploadFontCommand
@@ -58,7 +68,11 @@ public partial class FontFamilyPicker : UserControl
         {
             if (e.NewValue is int newIndex)
             {
-                sender.FontIndex = newIndex;
+                if (sender.Fonts is null || sender.Fonts.Count == 0)
+                {
+                    return;
+                }
+
                 if (newIndex < 0 || newIndex >= sender.Fonts.Count)
                 {
                     sender.FontIndex = sender.Fonts.IndexOf(sender.SelectedFontFamily);
@@ -107,5 +121,35 @@ public partial class FontFamilyPicker : UserControl
 
             FontIndex = Fonts.IndexOf(familyName);
         }
+    }
+
+    private void FontList_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (sender is not ListBox listBox || listBox.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        FontDropDown.Flyout?.Hide();
+    }
+
+    private void FontItem_OnPointerEntered(object? sender, PointerEventArgs e)
+    {
+        if (sender is not Control { DataContext: FontFamilyName fontFamily })
+        {
+            return;
+        }
+
+        PreviewFontIndex = Fonts.IndexOf(fontFamily);
+    }
+
+    private void FontList_OnPointerExited(object? sender, PointerEventArgs e)
+    {
+        PreviewFontIndex = -1;
+    }
+
+    private void FontFlyout_OnClosed(object? sender, EventArgs e)
+    {
+        PreviewFontIndex = -1;
     }
 }

--- a/src/PixiEditor/Views/Tools/ToolSettings/Settings/FontFamilySettingView.axaml
+++ b/src/PixiEditor/Views/Tools/ToolSettings/Settings/FontFamilySettingView.axaml
@@ -16,5 +16,6 @@
     </Design.DataContext>
 
     <input:FontFamilyPicker FontIndex="{Binding FontIndex, Mode=TwoWay}"
+                                 PreviewFontIndex="{Binding PreviewFontIndex, Mode=TwoWay}"
                                  Fonts="{Binding Fonts, Mode=OneWayToSource}"/>
 </UserControl>


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

- Reworked tool bar Font Dropdown.
  - Added more styling and
  - Added live font previewing for selected text in the viewport

Relies on to function: https://github.com/PixiEditor/PixiEditor/pull/1533

From original PR: https://github.com/PixiEditor/PixiEditor/pull/1522

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
