### PR TITLE
Fix NodePicker Navigation

### DIFF
--- a/src/PixiEditor/Views/Nodes/NodePicker.cs
+++ b/src/PixiEditor/Views/Nodes/NodePicker.cs
@@ -141,27 +141,29 @@ public partial class NodePicker : TemplatedControl
 
     private void Scrolled(object? sender, ScrollChangedEventArgs e)
     {
-        if (e.OffsetDelta.Y != 0)
+        if (e.OffsetDelta.Y == 0 || _scrollViewer == null || _itemsControl == null)
         {
-            if(_scrollViewer.ScrollBarMaximum.Y == 0)
-            {
-                return;
-            }
-            
-            double normalizedY = ScrollOffset.Y / _scrollViewer.ScrollBarMaximum.Y;
-
-            int index = (int)(normalizedY * _itemsControl.Items.Count);
-            index = Math.Clamp(index, 0, _itemsControl.Items.Count - 1);
-            string category = FilteredNodeGroups[index].Name;
-            if (string.IsNullOrEmpty(category))
-            {
-                category = MiscCategory;
-            }
-
-            SuppressCategoryChanged = true;
-            SelectedCategory = category;
-            SuppressCategoryChanged = false;
+            return;
         }
+
+        var topGroup = FilteredNodeGroups?.LastOrDefault(x => GetGroupTop(x) <= ScrollOffset.Y + 1)
+                       ?? FilteredNodeGroups?.FirstOrDefault();
+        if (topGroup == null)
+        {
+            return;
+        }
+
+        string category = string.IsNullOrEmpty(topGroup.Name) ? MiscCategory : topGroup.Name;
+
+        SuppressCategoryChanged = true;
+        SelectedCategory = category;
+        SuppressCategoryChanged = false;
+    }
+
+    private double? GetGroupTop(NodeTypeGroup group)
+    {
+        var container = _itemsControl?.ContainerFromItem(group);
+        return container?.TranslatePoint(new Point(0, 0), _itemsControl)?.Y;
     }
 
     private static void OnSearchQueryChanged(AvaloniaPropertyChangedEventArgs e)
@@ -375,17 +377,19 @@ public partial class NodePicker : TemplatedControl
                 return;
             }
 
-            int indexOfFirstItemInCategory = nodePicker.FilteredNodeGroups
-                .Select((x, i) => (x, i))
-                .FirstOrDefault(x => x.x.Name == nodePicker.SelectedCategory).i;
+            var group = nodePicker.FilteredNodeGroups?.FirstOrDefault(x => x.Name == nodePicker.SelectedCategory);
+            if (group == null)
+            {
+                return;
+            }
 
-            double normalizedY = indexOfFirstItemInCategory / (double)nodePicker.FilteredNodeGroups.Count;
+            double? y = nodePicker.GetGroupTop(group);
+            if (y == null)
+            {
+                return;
+            }
 
-            double y = normalizedY * nodePicker._scrollViewer.ScrollBarMaximum.Y;
-
-            if (double.IsNaN(y)) return;
-
-            nodePicker.ScrollOffset = new Vector(0, y);
+            nodePicker.ScrollOffset = new Vector(0, y.Value);
         }
     }
 }


### PR DESCRIPTION
my biggest annoyance finally gone lol

 ## Clearly describe changes, as detailed as possible

NodePicker now calculates the top of each category instead of assuming all categories have equal size (they don't)

old behavior:

https://github.com/user-attachments/assets/58a8a6f3-04d4-47b1-ab3c-d998c7b0b25f

new behavior:

https://github.com/user-attachments/assets/ac4db3cb-bcfe-4720-9146-a4b4e0aa3da1


## SELECT BELOW TO CONTINUE
- [ ] I wrote tests for my changes (if possible)
- [ ] I've included XML docs inside the code in relevant places
- [X] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
