### PR TITLE
fix(ui): added a scrollbar to Blackboard and prevent it from clipping

### DIFF
--- a/src/PixiEditor/Views/Blackboard/BlackboardView.axaml
+++ b/src/PixiEditor/Views/Blackboard/BlackboardView.axaml
@@ -11,9 +11,9 @@
              x:Class="PixiEditor.Views.Blackboard.BlackboardView">
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
@@ -38,18 +38,19 @@
 
         <Separator Background="{DynamicResource ThemeControlHighBrush}" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,5"/>
 
-        <ItemsControl Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
-            ItemsSource="{Binding Variables, RelativeSource={RelativeSource AncestorType=blackboard:BlackboardView, Mode=FindAncestor}}">
-            <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <StackPanel Spacing="5" Orientation="Vertical" />
-                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <blackboard:VariableView DataContext="{Binding}" />
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
+        <ScrollViewer Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{Binding Variables, RelativeSource={RelativeSource AncestorType=blackboard:BlackboardView, Mode=FindAncestor}}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Spacing="5" Orientation="Vertical" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <blackboard:VariableView DataContext="{Binding}" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/src/PixiEditor/Views/Dock/NodeGraphDockView.axaml
+++ b/src/PixiEditor/Views/Dock/NodeGraphDockView.axaml
@@ -8,8 +8,10 @@
              xmlns:overlays="clr-namespace:PixiEditor.Views.Overlays"
              xmlns:blackboard="clr-namespace:PixiEditor.Views.Blackboard"
              xmlns:ui="clr-namespace:PixiEditor.Helpers.UI"
+             xmlns:converters="clr-namespace:PixiEditor.Helpers.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="dock:NodeGraphDockViewModel"
+             x:Name="root"
              x:Class="PixiEditor.Views.Dock.NodeGraphDockView">
     <Design.DataContext>
         <dock:NodeGraphDockViewModel />
@@ -26,7 +28,8 @@
                         CornerRadius="{DynamicResource ControlCornerRadius}"
                         BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                         BorderThickness="{DynamicResource ThemeBorderThickness}"
-                        Background="{DynamicResource ThemeBackgroundBrush1}" ZIndex="2">
+                        Background="{DynamicResource ThemeBackgroundBrush1}" ZIndex="2"
+                        MaxHeight="{Binding #root.Bounds.Height, Converter={converters:SubtractConverter}, ConverterParameter=40}">
                     <blackboard:BlackboardView
                         Variables="{ReflectionBinding Path=DataContext.DocumentManagerSubViewModel.ActiveDocument.NodeGraph.Blackboard.Variables, RelativeSource={RelativeSource AncestorType=overlays:TogglableFlyout, Mode=FindAncestor}}"
                         AddVariableCommand="{xaml:Command PixiEditor.NodeGraph.AddVariable, UseProvided=True}" />


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible
When creating several blackboard variables that go beyond the monitor dimensions, it was previously impossible to scroll down and access them.
This change resolves the issue by:

Wrapping the ItemsControl inside BlackboardView.axaml in a ScrollViewer with VerticalScrollBarVisibility="Auto" and a bottom margin to prevent clipping against the status bar.

Adding a MaxHeight="{Binding $parent[UserControl].Bounds.Height}" constraint to the parent Border inside NodeGraphDockView.axaml to prevent infinite height expansion.

 ## If possible, show examples of usage

_a video, screenshots, text description_


https://github.com/user-attachments/assets/f8a1023d-7f8e-4528-89a8-9da43b95b92a

The first blackboard uses the unedited blackboard that shows the variables going beyond the monitor dimensions. The next one shows the scroll wheel appearing when the amount of variables go beyond the monitor dimensions. 


## SELECT BELOW TO CONTINUE
- - [ ] I wrote tests for my changes (if possible)
- - [ ] I've included XML docs inside the code in relevant places
- - [ x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
