### PR TITLE
Autosaver is now explicitly enabled for opened documents, not automatically

### DIFF
--- a/src/PixiEditor/ViewModels/Document/AutosaveDocumentViewModel.cs
+++ b/src/PixiEditor/ViewModels/Document/AutosaveDocumentViewModel.cs
@@ -34,6 +34,7 @@ internal class AutosaveDocumentViewModel : ObservableObject
 
     private DocumentAutosaver? autosaver;
     private DocumentViewModel Document { get; }
+    private DocumentInternalParts internals;
     private Guid autosaveFileGuid = Guid.NewGuid();
     public string AutosavePath => AutosaveHelper.GetNewAutosavePath(autosaveFileGuid);
 
@@ -53,6 +54,11 @@ internal class AutosaveDocumentViewModel : ObservableObject
     public AutosaveDocumentViewModel(DocumentViewModel document, DocumentInternalParts internals)
     {
         Document = document;
+        this.internals = internals;
+    }
+
+    public void EnableAutosaver()
+    {
         internals.ChangeController.ToolSessionFinished += (() => autosaver?.OnUpdateableChangeEnded());
         IPreferences.Current!.AddCallback(PreferencesConstants.AutosaveEnabled, PreferenceUpdateCallback);
         IPreferences.Current!.AddCallback(PreferencesConstants.AutosavePeriodMinutes, PreferenceUpdateCallback);

--- a/src/PixiEditor/ViewModels/Document/DocumentManagerViewModel.cs
+++ b/src/PixiEditor/ViewModels/Document/DocumentManagerViewModel.cs
@@ -317,6 +317,7 @@ internal class DocumentManagerViewModel : SubViewModel<ViewModelMain>, IDocument
     public void Add(DocumentViewModel doc)
     {
         Documents.Add(doc);
+        doc.AutosaveViewModel.EnableAutosaver();
         DocumentAdded?.Invoke(doc);
     }
 


### PR DESCRIPTION
 ## Clearly describe changes, as detailed as possible

Prevents autosave from autosaving unrelated files like brushes

 ## If possible, show examples of usage

_a video, screenshots, text description_

## SELECT BELOW TO CONTINUE
- - [ ] I wrote tests for my changes (if possible)
- - [ ] I've included XML docs inside the code in relevant places
- - [x] I agree to [PixiEditor's Code of Conduct](https://github.com/PixiEditor/PixiEditor/blob/master/CODE_OF_CONDUCT.md)
